### PR TITLE
Handling erroring error callback

### DIFF
--- a/R/req-error.R
+++ b/R/req-error.R
@@ -33,5 +33,14 @@ error_is_error <- function(req, resp) {
 }
 
 error_body <- function(req, resp) {
-  req_policy_call(req, "error_body", list(resp), default = NULL)
+  tryCatch(
+    req_policy_call(req, "error_body", list(resp), default = NULL),
+    error = function(cnd) {
+      cnd <- cnd_entrace(cnd)
+      c(
+        "`body` callback defined in req_error() failed with error:",
+        conditionMessage(cnd)
+      )
+    }
+  )
 }

--- a/R/req-error.R
+++ b/R/req-error.R
@@ -42,7 +42,7 @@ error_body <- function(req, resp) {
         "Additionally, req_error(body = ) failed with error:",
         gsub("\n", "\n  ", conditionMessage(cnd))
       )
-      if (packageVersion("rlang") >= "0.4.11.9001") {
+      if (utils::packageVersion("rlang") >= "0.4.11.9001") {
         names(msg)[[3]] <- " "
       }
       msg

--- a/R/req-error.R
+++ b/R/req-error.R
@@ -33,14 +33,19 @@ error_is_error <- function(req, resp) {
 }
 
 error_body <- function(req, resp) {
+  # TODO: revisit once rlang has better support for this
   tryCatch(
     req_policy_call(req, "error_body", list(resp), default = NULL),
     error = function(cnd) {
-      cnd <- cnd_entrace(cnd)
-      c(
-        "`body` callback defined in req_error() failed with error:",
-        conditionMessage(cnd)
+      msg <- c(
+        "",
+        "Additionally, req_error(body = ) failed with error:",
+        gsub("\n", "\n  ", conditionMessage(cnd))
       )
+      if (packageVersion("rlang") >= "0.4.11.9001") {
+        names(msg)[[3]] <- " "
+      }
+      msg
     }
   )
 }

--- a/tests/testthat/_snaps/req-error.md
+++ b/tests/testthat/_snaps/req-error.md
@@ -1,5 +1,21 @@
 # failing callback still generates useful body
 
-    [1] "`body` callback defined in req_error() failed with error:"
-    [2] "This is an error!"                                        
+    [1] ""                                                   
+    [2] "Additionally, req_error(body = ) failed with error:"
+    [3] "This is an error!"                                  
+
+---
+
+    Code
+      req <- request("https://httpbin.org/status/404")
+      req <- req %>% req_error(body = ~resp_body_json(.x)$error)
+      req %>% req_perform()
+    Error <httr2_http_404>
+      HTTP 404 Not Found.
+      * 
+      * Additionally, req_error(body = ) failed with error:
+      * Unexpected content type 'text/html'
+        * Expecting 'application/json'
+        * Or suffix '+json'
+        i Override check with `check_type = FALSE`
 

--- a/tests/testthat/_snaps/req-error.md
+++ b/tests/testthat/_snaps/req-error.md
@@ -1,0 +1,5 @@
+# failing callback still generates useful body
+
+    [1] "`body` callback defined in req_error() failed with error:"
+    [2] "This is an error!"                                        
+

--- a/tests/testthat/test-req-error.R
+++ b/tests/testthat/test-req-error.R
@@ -15,3 +15,8 @@ test_that("can customise error info", {
   req <- req %>% req_error(body = ~ "Hi!")
   expect_equal(error_body(req, response(404)), "Hi!")
 })
+
+test_that("failing callback still generates useful body", {
+  req <- request_test() %>% req_error(body = ~ abort("This is an error!"))
+  expect_snapshot_output(error_body(req, response(404)))
+})

--- a/tests/testthat/test-req-error.R
+++ b/tests/testthat/test-req-error.R
@@ -19,4 +19,10 @@ test_that("can customise error info", {
 test_that("failing callback still generates useful body", {
   req <- request_test() %>% req_error(body = ~ abort("This is an error!"))
   expect_snapshot_output(error_body(req, response(404)))
+
+  expect_snapshot(error = TRUE, {
+    req <- request("https://httpbin.org/status/404")
+    req <- req %>% req_error(body = ~ resp_body_json(.x)$error)
+    req %>% req_perform()
+  })
 })


### PR DESCRIPTION
Fixes #63

@lionel- does this seem right to you? I want to make sure that if someone developing an API wrapper accidentally messes up the  code for parsing addition error text it doesn't lead to a super confusing error for the user.