### PR TITLE
Fix typo in documentation

### DIFF
--- a/R/curl.R
+++ b/R/curl.R
@@ -1,8 +1,8 @@
 #' Translate curl syntax to httr2
 #'
 #' @description
-#' The curl command line tool is commonly to demonstrate HTTP APIs and can
-#' easily be be generated from
+#' The curl command line tool is commonly used to demonstrate HTTP APIs and can
+#' easily be generated from
 #' [browser developer tools](https://everything.curl.dev/usingcurl/copyas).
 #' `curl_translate()` saves you the pain of manually translating these calls
 #' by implementing a partial, but frequently used, subset of curl options.

--- a/man/curl_translate.Rd
+++ b/man/curl_translate.Rd
@@ -19,8 +19,8 @@ was copied from the clipboard, the translation will be copied back
 to the clipboard.
 }
 \description{
-The curl command line tool is commonly to demonstrate HTTP APIs and can
-easily be be generated from
+The curl command line tool is commonly used to demonstrate HTTP APIs and can
+easily be generated from
 \href{https://everything.curl.dev/usingcurl/copyas}{browser developer tools}.
 \code{curl_translate()} saves you the pain of manually translating these calls
 by implementing a partial, but frequently used, subset of curl options.


### PR DESCRIPTION
Fixes a minor issue in the curl documentation entry. 