### PR TITLE
Device Code + PKCE implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* Added PKCE support to `oauth_flow_device()` (@flahn, #92).
+
 # httr2 0.1.1
 
 * Fix R CMD check failures on CRAN

--- a/R/oauth-flow-device.R
+++ b/R/oauth-flow-device.R
@@ -75,14 +75,12 @@ oauth_flow_device <- function(client,
   # Google uses verification_url instead of verification_uri
   # verification_uri_complete is optional, it would ship the user
   # code in the uri https://datatracker.ietf.org/doc/html/rfc8628#section-3.2
-  if (is_interactive() && has_name(request, "verification_uri_complete")) {
+  url <- request$verification_uri_complete %||% request$verification_uri %||% request$verification_url
+
+  if (is_interactive()) {
     inform(glue("Use code {request$user_code}"))
     utils::browseURL(request$verification_uri_complete)
-  } else if (is_interactive() && has_name(request, "verification_uri")) {
-    inform(glue("Use code {request$user_code}"))
-    utils::browseURL(request$verification_uri)
   } else {
-    url <- request$verification_uri %||% request$verification_url
     inform(glue("Visit <{url}> and enter code {request$user_code}"))
   }
 

--- a/R/oauth-flow-device.R
+++ b/R/oauth-flow-device.R
@@ -79,7 +79,7 @@ oauth_flow_device <- function(client,
 
   if (is_interactive()) {
     inform(glue("Use code {request$user_code}"))
-    utils::browseURL(request$verification_uri_complete)
+    utils::browseURL(url)
   } else {
     inform(glue("Visit <{url}> and enter code {request$user_code}"))
   }

--- a/R/oauth-flow.R
+++ b/R/oauth-flow.R
@@ -12,7 +12,7 @@ oauth_flow_fetch <- function(req) {
     body <- NULL
   }
 
-  if (has_name(body, "access_token") && resp_status(resp) == 200) {
+  if ((has_name(body, "access_token") || has_name(body, "device_code")) && resp_status(resp) == 200) {
     body
   } else if (has_name(body, "error")) {
     oauth_flow_abort(body$error, body$error_description, body$error_uri)

--- a/man/oauth_flow_device.Rd
+++ b/man/oauth_flow_device.Rd
@@ -7,6 +7,7 @@
 oauth_flow_device(
   client,
   auth_url,
+  pkce = FALSE,
   scope = NULL,
   auth_params = list(),
   token_params = list()
@@ -17,6 +18,9 @@ oauth_flow_device(
 
 \item{auth_url}{Authorization url; you'll need to discover this by reading
 the documentation.}
+
+\item{pkce}{Use "Proof Key for Code Exchange"? This adds an extra layer of
+security and should always be used if supported by the server.}
 
 \item{scope}{Scopes to be requested from the resource owner.}
 
@@ -34,6 +38,13 @@ by \href{https://datatracker.ietf.org/doc/html/rfc8628}{rfc8628}. It's designed
 for devices that don't have access to a web browser (if you've ever
 authenticated an app on your TV, this is probably the flow you've used),
 but it also works well from within R.
+
+This specification allows also some subspecifications:
+\itemize{
+\item \code{oauth_flow_auth_code_pkce()} is also reused here to generate code
+verifier, method, and challenge components as needed for PKCE, as
+defined in \href{https://datatracker.ietf.org/doc/html/rfc7636}{rfc7636}.
+}
 }
 \seealso{
 Other OAuth flows: 


### PR DESCRIPTION
A follow-up implementation for r-lib/httr2#92 which adds the option to use PKCE during the device code flow authentication. The implementation follows the existing one for the authentication code flow.