### PR TITLE
Documentation typos

### DIFF
--- a/R/resp-body.R
+++ b/R/resp-body.R
@@ -58,7 +58,7 @@ resp_body_string <- function(resp, encoding = NULL) {
 #'   `FALSE` to suppress the automated check
 #' @param simplifyVector Should JSON arrays containing only primitives (i.e.
 #'   booleans, numbers, and strings) be caused to atomic vectors?
-#' @param ... Other argumented passed on to [jsonlite::fromJSON()] and
+#' @param ... Other arguments passed on to [jsonlite::fromJSON()] and
 #'   [xml2::read_xml()] respectively.
 #' @rdname resp_body_raw
 #' @export

--- a/man/resp_body_raw.Rd
+++ b/man/resp_body_raw.Rd
@@ -32,7 +32,7 @@ always re-encoded to UTF-8.}
 \item{simplifyVector}{Should JSON arrays containing only primitives (i.e.
 booleans, numbers, and strings) be caused to atomic vectors?}
 
-\item{...}{Other argumented passed on to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}} and
+\item{...}{Other arguments passed on to \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}} and
 \code{\link[xml2:read_xml]{xml2::read_xml()}} respectively.}
 }
 \value{

--- a/vignettes/wrapping-apis.Rmd
+++ b/vignettes/wrapping-apis.Rmd
@@ -256,7 +256,7 @@ There are three basic steps to this process:
     secret_scrambled
     ```
 
-3.  When needed, you descramble the the secret using `secret_decrypt()`:
+3.  When needed, you descramble the secret using `secret_decrypt()`:
 
     ```{r}
     secret_decrypt(secret_scrambled, key)

--- a/vignettes/wrapping-apis.Rmd
+++ b/vignettes/wrapping-apis.Rmd
@@ -343,7 +343,7 @@ Note that including an API key as a query parameter is relatively insecure; if a
 Here it only takes a couple of minutes to generate your own NYTimes API key, so there's little incentive for someone to try and steal yours.
 
 The main problem of conveying credentials via the url is that it's easily exposed, because httr2 makes no efforts to redact confidential information stored in query parameters.
-This means it's relatively easy to leak your key if you use `req_perform(verbose = 1)`, `req_dry_run()`, or even just print the request object.
+This means it's relatively easy to leak your key if you use `req_perform(verbosity = 1)`, `req_dry_run()`, or even just print the request object.
 And indeed, you'll see that in the examples below --- this is bad practice for a real package, but I think it's ok here because the key doesn't allow you to do anything valuable and it makes teaching APIs so much easier.
 
 ### Basic request


### PR DESCRIPTION
Fixed the repeated word "the" and the mention to the `verbose` argument that should have been `verbosity`, in the vignette "wrapping-apis". Also, fixed "argumented" to the most likely intended "arguments" in `resp_body_json()` function.