### PR TITLE
Make actual request rate equal to expected, fixes #101

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_throttle()` correctly sets throttle rate (@jchrom, #101).
+
 * `req_error()` can now correct force successful HTTP statuses to fail (#98).
 
 * `req_headers()` will now override `Content-Type` set by `req_body_*()` (#116)

--- a/R/req-throttle.R
+++ b/R/req-throttle.R
@@ -33,6 +33,7 @@ req_throttle <- function(req, rate, realm = NULL) {
       wait <- delay - (unix_time() - last)
     }
 
+    sys_sleep(wait)
     throttle_touch(realm)
     wait
   }

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -46,7 +46,7 @@ test_that("req_perform() will throttle requests", {
   skip_on_cran()
   throttle_reset()
 
-  req <- request_test() %>% req_throttle(10 / 1)
+  req <- request_test() %>% req_throttle(2 / 1)
   cnd <- req %>% req_perform() %>% catch_cnd("httr2_sleep")
   expect_null(cnd)
 

--- a/tests/testthat/test-req-throttle.R
+++ b/tests/testthat/test-req-throttle.R
@@ -6,6 +6,21 @@ test_that("throttling causes delay", {
   expect_true(throttle_delay(req) > 0.005)
 })
 
+test_that("20 requests at rate 4/s take ~5 seconds to run", {
+  skip_on_cran()
+  throttle_reset()
+
+  req <- request_test() %>% req_throttle(4)
+
+  # Ensure all 20 requests below will have to wait.
+  req_perform(req)
+
+  elapsed <- system.time(rep(list(req), 20) %>% lapply(req_perform))[[3]]
+
+  expect_gt(elapsed, 4)
+  expect_lt(elapsed, 6)
+})
+
 test_that("realm defaults to hostname but can be overridden", {
   throttle_reset()
   expect_equal(the$throttle, list())

--- a/tests/testthat/test-req-throttle.R
+++ b/tests/testthat/test-req-throttle.R
@@ -14,10 +14,10 @@ test_that("throttling causes expected average request rate", {
 
   elapsed <- replicate(20, system.time(req_perform(req)))["elapsed", ]
 
-  trimmed <- mean(elapsed, trim = 0.10)
+  trimmed <- mean(elapsed, trim = 0.2)
 
-  expect_gt(trimmed, 0.08)
-  expect_lt(trimmed, 0.12)
+  expect_gt(trimmed, 0.09)
+  expect_lt(trimmed, 0.13)
 })
 
 test_that("realm defaults to hostname but can be overridden", {

--- a/tests/testthat/test-req-throttle.R
+++ b/tests/testthat/test-req-throttle.R
@@ -6,19 +6,18 @@ test_that("throttling causes delay", {
   expect_true(throttle_delay(req) > 0.005)
 })
 
-test_that("20 requests at rate 4/s take ~5 seconds to run", {
+test_that("throttling causes expected average request rate", {
   skip_on_cran()
   throttle_reset()
 
-  req <- request_test() %>% req_throttle(4)
+  req <- request_test() %>% req_throttle(10)
 
-  # Ensure all 20 requests below will have to wait.
-  req_perform(req)
+  elapsed <- replicate(20, system.time(req_perform(req)))["elapsed", ]
 
-  elapsed <- system.time(rep(list(req), 20) %>% lapply(req_perform))[[3]]
+  trimmed <- mean(elapsed, trim = 0.10)
 
-  expect_gt(elapsed, 4)
-  expect_lt(elapsed, 6)
+  expect_gt(trimmed, 0.08)
+  expect_lt(trimmed, 0.12)
 })
 
 test_that("realm defaults to hostname but can be overridden", {

--- a/tests/testthat/test-req-throttle.R
+++ b/tests/testthat/test-req-throttle.R
@@ -17,7 +17,7 @@ test_that("throttling causes expected average request rate", {
   trimmed <- mean(elapsed, trim = 0.2)
 
   expect_gt(trimmed, 0.09)
-  expect_lt(trimmed, 0.13)
+  expect_lt(trimmed, 0.14)
 })
 
 test_that("realm defaults to hostname but can be overridden", {


### PR DESCRIPTION
Fixes the problem with `throttle_delay()` where the actual time requests take is half of what you would expect.

### What I've done:

- moved `sys_sleep()` inside `throttle_delay()` so that `throttle_touch()` can happen after it and still find the correct realm
- removed the original `sys_sleep()`
- added `sys_sleep()` where appropriate to preserve the expected behavior on backoff, reauth and retry after

### Tests

The original test in _test-req-throttle.R_ passes as is, because the value of `wait` is still returned (now only useful for testing).

I also tested manually using httpbin to ensure times are now as expected.

I experimented with including tests where I was issuing requests via a fake app, so I could measure the elapsed time. This worked, but when set to very high rates, even a slight discrepancy in wait time would make the test fail on occasion, unless a high tolerance was used, which then kind of defeats the test. Lower request rates were more reliable, but then the test takes a long time to execute. It could be skipped on CRAN though.
