### PR TITLE
Preserve class in `req_body_*`, fixes #95

### DIFF
--- a/R/req-body.R
+++ b/R/req-body.R
@@ -101,7 +101,9 @@ req_body_json <- function(req, data,
     null = null,
     ...
   )
-  data <- modify_list(req$body$data, !!!data)
+
+  data <- merge_body_data(req$body$data, data)
+
   req_body(req, data = data, type = "json", params = params)
 }
 
@@ -111,7 +113,8 @@ req_body_form <- function(req, data) {
   check_request(req)
   check_body_data(data)
 
-  data <- modify_list(req$body$data, !!!data)
+  data <- merge_body_data(req$body$data, data)
+
   req_body(req, data = data, type = "form")
 }
 
@@ -121,7 +124,8 @@ req_body_multipart <- function(req, data) {
   check_request(req)
   check_body_data(data)
 
-  data <- modify_list(req$body$data, !!!data)
+  data <- merge_body_data(req$body$data, data)
+
   # data must be character, raw, curl::form_file, or curl::form_data
   req_body(req, data = data, type = "multipart")
 }
@@ -232,4 +236,17 @@ check_body_data <- function(data) {
   if (!is_named(data)) {
     abort("All elements of `data` must be named")
   }
+}
+
+merge_body_data <- function(old, new) {
+
+  if (!is.object(new) && !is.object(old)) {
+    return(modify_list(old, !!!new))
+  }
+
+  if (length(old)) {
+    warn(glue::glue("Replacing existing body, {friendly_type_of(old)}, with {friendly_type_of(new)}"))
+  }
+
+  new
 }

--- a/tests/testthat/test-req-body.R
+++ b/tests/testthat/test-req-body.R
@@ -47,6 +47,28 @@ test_that("can send named list as json/form/multipart", {
   expect_equal(json$form, list(a = "1", b = "2"))
 })
 
+test_that("class attribute is preserved", {
+  req <- request_test() %>% req_body_json(mtcars)
+  expect_equal(req$body$data, mtcars)
+})
+
+test_that("warns on body replacement", {
+
+  req <- request_test() %>% req_body_json(mtcars)
+
+  expect_warning(
+    req %>% req_body_json(list(a = 1)),
+    "Replacing existing body, a <data.frame> object, with a list"
+  )
+
+  req <- request_test() %>% req_body_json(list(a = 1))
+
+  expect_warning(
+    req %>% req_body_json(mtcars),
+    "Replacing existing body, a list, with a <data.frame> object"
+  )
+})
+
 test_that("can modify body data", {
   req1 <- request_test() %>% req_body_form(list(a = 1))
   req2 <- req1 %>% req_body_form(list(b = 2))


### PR DESCRIPTION
## The issue

The problem with `modify_list()` in #95 is that it drops the class attribute, which makes `jsonlite::toJSON()` unable to correctly process data frames.

I added `merge_body_data()` (not exported) which **changes the default behavior** if old or new body returns TRUE for `is.object()`. In such case, the old body is replaced with the new without further modification. If the old body was of non-zero length, a warning is signaled.

The added benefit of this approach is that you can trigger the replacement behavior at will by wrapping the new body in `I()`, e.g. `req_body_json(req, data = I(x))`.

## Affected functions:

- `req_body_json()`
- `req_body_form()`
- `req_body_multipart()`

## Tests

Added tests for body replacement and warnings. Everything passes locally.

