### PR TITLE
Keep duplicates in `modify_list()`, fixes #97, fixes #107

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -47,10 +47,14 @@ replace2 <- function(x, y) {
     xi <- which(names(x) == nm)
     yi <- which(names(y) == nm)
 
+    # Replace all occurrences of `nm` in `x` with the same number of occurrences
+    # from `y`.
     x[xi[seq_along(xi) <= length(yi)]] <- y[yi[seq_along(yi) <= length(xi)]]
 
+    # If there is a leftover on the part of `x`, it is dropped.
     x[xi[seq_along(xi) > length(yi)]] <- NULL
 
+    # If leftover happens on the part of `y`, it is appended.
     x <- c(x, y[yi[seq_along(yi) > length(xi)]])
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,15 +21,16 @@ bullets_with_header <- function(header, x) {
   cli::cli_li(paste0("{.field ", names(x), "}: ", vals))
 }
 
-modify_list <- function(.x, ...) {
+modify_list <- function(.x, ..., .compact = TRUE) {
   dots <- list2(...)
   if (length(dots) == 0) return(.x)
 
   if (!is_named(dots)) {
     abort("All components of ... must be named")
   }
-  .x[names(dots)] <- dots
-  out <- compact(.x)
+
+  out <- replace2(.x, dots) %>% compact()
+
   if (length(out) == 0) {
     names(out) <- NULL
   }
@@ -37,6 +38,24 @@ modify_list <- function(.x, ...) {
   out
 }
 
+# Replace elements in `x` with elements in `y`, preserving the original ordering
+# where applicable, and preserving duplicates found in `y`.
+replace2 <- function(x, y) {
+
+  for (nm in unique(names(y))) {
+
+    xi <- which(names(x) == nm)
+    yi <- which(names(y) == nm)
+
+    x[xi[seq_along(xi) <= length(yi)]] <- y[yi[seq_along(yi) <= length(xi)]]
+
+    x[xi[seq_along(xi) > length(yi)]] <- NULL
+
+    x <- c(x, y[yi[seq_along(yi) > length(xi)]])
+  }
+
+  x
+}
 
 sys_sleep <- function(seconds) {
   check_number(seconds, "`seconds`")

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,7 +21,7 @@ bullets_with_header <- function(header, x) {
   cli::cli_li(paste0("{.field ", names(x), "}: ", vals))
 }
 
-modify_list <- function(.x, ..., .compact = TRUE) {
+modify_list <- function(.x, ...) {
   dots <- list2(...)
   if (length(dots) == 0) return(.x)
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -9,6 +9,11 @@ test_that("modify list adds, removes, and overrides", {
   expect_snapshot(modify_list(x, a = 1, 2), error = TRUE)
 })
 
+test_that("`modify_list()` preserves duplicates in `y`", {
+  x <- list(x = 1, y = 2)
+  expect_equal(modify_list(x, y = 3, y = 4), list(x = 1, y = 3, y = 4))
+})
+
 test_that("can check arg types", {
   expect_snapshot(error = TRUE, {
     check_string(1, "x")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -9,7 +9,7 @@ test_that("modify list adds, removes, and overrides", {
   expect_snapshot(modify_list(x, a = 1, 2), error = TRUE)
 })
 
-test_that("`modify_list()` preserves duplicates in `y`", {
+test_that("`modify_list()` preserves duplicates in `...`", {
   x <- list(x = 1, y = 2)
   expect_equal(modify_list(x, y = 3, y = 4), list(x = 1, y = 3, y = 4))
 })


### PR DESCRIPTION
# The issue

When `...` in `modify_list()` includes duplicates, they get silently dropped. This is inconvenient mainly in `req_body_*` and `req_url_query()`. Note e.g. the WHATWG URL Standard seems to allow for non-unique query parameters (see this [nice SO answer](https://stackoverflow.com/a/70264621) with references).

# Change in default behavior

```
x <- list(m = 1)
httr2:::modify_list(x, n = 1, n = 2)
```

Result before change: 

`list(m = 1, n = 2)`

Result after change:

`list(m = 1, n = 1, n = 2)`

# Tests

Added a test for preserving duplicates. All previous tests pass locally as well.