### PR TITLE
Bug fix in `auth_flags`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_proxy()` now uses the appropriate authentication option (@jl5000).
+
 # httr2 0.2.1
 
 * "Wrapping APIs" is now an article, not a vignette.

--- a/R/req-options.R
+++ b/R/req-options.R
@@ -222,5 +222,5 @@ auth_flags <- function(x = "basic") {
     any = -17
   )
   idx <- arg_match0(x, names(constants), arg_nm = "auth", error_call = caller_env())
-  constants[[]]
+  constants[[idx]]
 }

--- a/tests/testthat/test-req-options.R
+++ b/tests/testthat/test-req-options.R
@@ -53,3 +53,9 @@ test_that("req_proxy gives helpful errors", {
   })
 
 })
+
+test_that("auth_flags gives correct constant", {
+  expect_equal(auth_flags("digest"), 2)
+  expect_equal(auth_flags("ntlm"), 8)
+  expect_equal(auth_flags("any"), -17)
+})


### PR DESCRIPTION
The code is erroring for me at this point and I'm pretty sure it's because the `idx` variable isn't being used.