### PR TITLE
`curl_translate()` can now handle line breaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* `curl_translate()` can now handle curl copied from Chrome developer tools
+  (@mgirlich, #161).
+
 * `req_url_query()` can now opt out of escaping with `I()` (@boshek, #152).
 
 * `req_proxy()` now uses the appropriate authentication option (@jl5000).

--- a/R/curl.R
+++ b/R/curl.R
@@ -213,6 +213,8 @@ curl_args <- function(cmd) {
     args <- parse_delim(pieces[[2]], " ", quote = '"')
   }
 
+  args <- args[args != "" & args != "\\"]
+
   parsed <- docopt::docopt(curl_opts, args = args, help = FALSE, strict = TRUE)
 
   # Drop default options

--- a/tests/testthat/test-curl.R
+++ b/tests/testthat/test-curl.R
@@ -30,6 +30,13 @@ test_that("captures key components of call", {
   expect_equal(curl_args("curl 'http://example.com' --verbose")$`--verbose`,  TRUE)
 })
 
+test_that("can handle line breaks", {
+  expect_equal(
+    curl_args("curl 'http://example.com' \\\n -H 'A: 1' \\\n -H 'B: 2'")$`--header`,
+    c("A: 1", "B: 2")
+  )
+})
+
 test_that("headers are parsed", {
   expect_equal(
     curl_normalize("curl http://x.com -H 'A: 1'")$headers,


### PR DESCRIPTION
Fixes #161.