### PR TITLE
More robust `parse_media()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* Can now print responses where content type is the empty string (@mgirlich, #163).
+
 * `curl_translate()` can now handle curl copied from Chrome developer tools
   (@mgirlich, #161).
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -3,7 +3,11 @@ parse_media <- function(x) {
   pieces <- parse_delim(x, ";")
   params <- parse_name_equals_value(pieces[-1])
 
-  c(list(type = pieces[[1]]), params)
+  if (is_empty(pieces)) {
+    list(type = NA_character_)
+  } else {
+    c(list(type = pieces[[1]]), params)
+  }
 }
 
 parse_www_authenticate <- function(x) {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -19,6 +19,8 @@ test_that("can parse media type", {
     parse_media("text/plain; charset=\";\""),
     list(type = "text/plain", charset = ";")
   )
+
+  expect_equal(parse_media(""), list(type = NA_character_))
 })
 
 test_that("can parse authenticate header", {


### PR DESCRIPTION
Fixes #163.
Similar issues could happen in `parse_www_authenticate()` and `parse_link()`. I'm not sure whether that could really happen but they use the same pattern.