### PR TITLE
Fix oauth refresh

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* OAuth tokens can now be refreshed. One, two, or even more times! (@jennybc, #166)
+
 * Can now print responses where content type is the empty string (@mgirlich, #163).
 
 * `curl_translate()` can now handle curl copied from Chrome developer tools

--- a/R/oauth-flow-refresh.R
+++ b/R/oauth-flow-refresh.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' This uses [oauth_flow_refresh()] to generate an access token, which is
-#' then used to authentication the request with [req_auth_bearer_token()].
+#' then used to authenticate the request with [req_auth_bearer_token()].
 #' This is primarily useful for testing: you can manually execute another OAuth
 #' flow (e.g. by calling [oauth_flow_auth_code()] or [oauth_flow_device()]),
 #' extract the refresh token from the result, and then save in an environment
@@ -67,7 +67,7 @@ oauth_flow_refresh <- function(client,
     token_params = token_params
   )
 
-  # Should generally do this automaitcaly, but in this workflow the token will
+  # Should generally do this automatically, but in this workflow the token will
   # often be stored in an env var or similar
   if (!is.null(token$refresh_token) && token$refresh_token != refresh_token) {
     abort("Refresh token has changed! Please update stored value")

--- a/R/oauth-token.R
+++ b/R/oauth-token.R
@@ -78,10 +78,13 @@ token_has_expired <- function(token, delay = 5) {
 }
 
 token_refresh <- function(client, refresh_token, scope = NULL, token_params = list()) {
-  oauth_client_get_token(client,
+  out <- oauth_client_get_token(
+    client,
     grant_type = "refresh_token",
     refresh_token = refresh_token,
     scope = scope,
     !!!token_params
   )
+  out$refresh_token <- out$refresh_token %||% refresh_token
+  out
 }

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -46,7 +46,7 @@ auth_oauth_sign <- function(req, reauth = FALSE) {
       if (is.null(token$refresh_token)) {
         token <- exec(flow, !!!flow_params)
       } else {
-        token <- token_refresh(flow$params$client, token)
+        token <- token_refresh(flow_params$client, token)
       }
     }
   }

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -46,7 +46,7 @@ auth_oauth_sign <- function(req, reauth = FALSE) {
       if (is.null(token$refresh_token)) {
         token <- exec(flow, !!!flow_params)
       } else {
-        token <- token_refresh(flow_params$client, token)
+        token <- token_refresh(flow_params$client, token$refresh_token)
       }
     }
   }

--- a/man/req_oauth_refresh.Rd
+++ b/man/req_oauth_refresh.Rd
@@ -32,7 +32,7 @@ A modified HTTP \link{request}.
 }
 \description{
 This uses \code{\link[=oauth_flow_refresh]{oauth_flow_refresh()}} to generate an access token, which is
-then used to authentication the request with \code{\link[=req_auth_bearer_token]{req_auth_bearer_token()}}.
+then used to authenticate the request with \code{\link[=req_auth_bearer_token]{req_auth_bearer_token()}}.
 This is primarily useful for testing: you can manually execute another OAuth
 flow (e.g. by calling \code{\link[=oauth_flow_auth_code]{oauth_flow_auth_code()}} or \code{\link[=oauth_flow_device]{oauth_flow_device()}}),
 extract the refresh token from the result, and then save in an environment


### PR DESCRIPTION
This fixes #166. ~Sort of.~ *I believe I've solved the multiple refresh problem also now.*

In my hands, I can only use a valid refresh token twice:

First, in the initial call that triggers the oauth dance in the browser. (With `cache_disk = TRUE`, the token that is written to disk includes both the refresh and access token.)

Then, with this PR, an initial refresh works, i.e. a new access token is obtained.

**But** after this first refresh, it looks like the token cached on disk, no longer includes the refresh token? In which case the next (3rd) attempt leads to a full oauth dance, when it should not. I'm still verifying and investigating this claim about the token on disk.

It's a slow process because to truly test things, you really do have to let access tokens expire. I'm testing against Google, where access tokens last for 60 minutes.

We could merge this, because it's progress. Or wait until I clear up the other matter.