### PR TITLE
removed oauth_flow_check() in oauth_flow_device

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* disabled check for interactive session `oauth_flow_check(..., interactive)` on device code flow to print URL and device code as intended (@flahn, #170)
+
 * The environment variable `HTTR2_REFRESH_TOKEN` replaces the previous `HTTR_REFRESH_TOKEN` (@jennybc, #169).
 
 * OAuth tokens can now be refreshed. One, two, or even more times! (@jennybc, #166)

--- a/R/oauth-flow-device.R
+++ b/R/oauth-flow-device.R
@@ -58,7 +58,6 @@ oauth_flow_device <- function(client,
                               scope = NULL,
                               auth_params = list(),
                               token_params = list()) {
-  oauth_flow_check("device", client, interactive = TRUE)
 
   if (pkce) {
     code <- oauth_flow_auth_code_pkce()

--- a/R/oauth-flow-device.R
+++ b/R/oauth-flow-device.R
@@ -58,6 +58,7 @@ oauth_flow_device <- function(client,
                               scope = NULL,
                               auth_params = list(),
                               token_params = list()) {
+  oauth_flow_check("device", client, interactive = is_interactive())
 
   if (pkce) {
     code <- oauth_flow_auth_code_pkce()


### PR DESCRIPTION
- fixes #170
- checking interactiveness at that point prevented the code block about printing url and device code for manual browser interaction from being ever executed