### PR TITLE
`req_url_path_*()` can handle empty `...`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # httr2 (development version)
 
-* `req_url_path()` and `req_url_path_append()` can handle `NULL` or empty `...`
-  (@mgirlich, #177).
+* `req_url_path()` and `req_url_path_append()` can now handle `NULL` or empty
+  `...` and the elements of `...` can also have length > 1 (@mgirlich, #177).
 
 * `req_perform()` now has an `error_call` argument and communicates more clearly
   where the error occurred (@mgirlich, #187).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* `req_url_path()` and `req_url_path_append()` can handle `NULL` or empty `...`
+  (@mgirlich, #177).
+
 # httr2 0.2.2
 
 * `curl_translate()` can now handle curl copied from Chrome developer tools

--- a/R/req-url.R
+++ b/R/req-url.R
@@ -53,8 +53,7 @@ req_url_query <- function(.req, ...) {
 #' @rdname req_url
 req_url_path <- function(req, ...) {
   check_request(req)
-  path <- paste(..., sep = "/")
-  path <- path_add_slash(path)
+  path <- dots_to_path(...)
 
   req_url(req, url_modify(req$url, path = path))
 }
@@ -63,19 +62,18 @@ req_url_path <- function(req, ...) {
 #' @rdname req_url
 req_url_path_append <- function(req, ...) {
   check_request(req)
-  path <- paste(..., sep = "/")
-  path <- path_add_slash(path)
+  path <- dots_to_path(...)
 
   url <- url_parse(req$url)
-
   url$path <- paste0(sub("/$", "", url$path), path)
 
   req_url(req, url_build(url))
 }
 
-path_add_slash <- function(path) {
+dots_to_path <- function(...) {
+  path <- paste(c(...), sep = "/", collapse = "/")
   # Ensure we don't add duplicate /s
-  if (!is_empty(path) && !grepl("^/", path)) {
+  if (path != "" && !grepl("^/", path)) {
     path <- paste0("/", path)
   }
 

--- a/R/req-url.R
+++ b/R/req-url.R
@@ -71,7 +71,7 @@ req_url_path_append <- function(req, ...) {
 }
 
 dots_to_path <- function(...) {
-  path <- paste(c(...), sep = "/", collapse = "/")
+  path <- paste(c(...), collapse = "/")
   # Ensure we don't add duplicate /s
   if (path != "" && !grepl("^/", path)) {
     path <- paste0("/", path)

--- a/R/req-url.R
+++ b/R/req-url.R
@@ -54,10 +54,7 @@ req_url_query <- function(.req, ...) {
 req_url_path <- function(req, ...) {
   check_request(req)
   path <- paste(..., sep = "/")
-
-  if (!grepl("^/", path)) {
-    path <- paste0("/", path)
-  }
+  path <- path_add_slash(path)
 
   req_url(req, url_modify(req$url, path = path))
 }
@@ -67,14 +64,20 @@ req_url_path <- function(req, ...) {
 req_url_path_append <- function(req, ...) {
   check_request(req)
   path <- paste(..., sep = "/")
+  path <- path_add_slash(path)
 
   url <- url_parse(req$url)
 
-  # Ensure we don't add duplicate /s
-  if (!grepl("^/", path)) {
-    path <- paste0("/", path)
-  }
   url$path <- paste0(sub("/$", "", url$path), path)
 
   req_url(req, url_build(url))
+}
+
+path_add_slash <- function(path) {
+  # Ensure we don't add duplicate /s
+  if (!is_empty(path) && !grepl("^/", path)) {
+    path <- paste0("/", path)
+  }
+
+  path
 }

--- a/tests/testthat/test-req-url.R
+++ b/tests/testthat/test-req-url.R
@@ -30,6 +30,15 @@ test_that("can handle empty path", {
   expect_equal(req_url_path_append(req)$url, "http://example.com/x")
   expect_equal(req_url_path(req, NULL)$url, "http://example.com")
   expect_equal(req_url_path_append(req, NULL)$url, "http://example.com/x")
+
+  expect_equal(req_url_path(req, "")$url, "http://example.com")
+  expect_equal(req_url_path_append(req, "")$url, "http://example.com/x")
+})
+
+test_that("can path vector", {
+  req <- request("http://example.com/x")
+  expect_equal(req_url_path(req, c("a", "b"))$url, "http://example.com/a/b")
+  expect_equal(req_url_path_append(req, c("a", "b"))$url, "http://example.com/x/a/b")
 })
 
 test_that("can set query params", {

--- a/tests/testthat/test-req-url.R
+++ b/tests/testthat/test-req-url.R
@@ -35,10 +35,11 @@ test_that("can handle empty path", {
   expect_equal(req_url_path_append(req, "")$url, "http://example.com/x")
 })
 
-test_that("can path vector", {
+test_that("can handle path vector", {
   req <- request("http://example.com/x")
   expect_equal(req_url_path(req, c("a", "b"))$url, "http://example.com/a/b")
   expect_equal(req_url_path_append(req, c("a", "b"))$url, "http://example.com/x/a/b")
+  expect_equal(req_url_path_append(req, c("a", "b"), NULL)$url, "http://example.com/x/a/b")
 })
 
 test_that("can set query params", {

--- a/tests/testthat/test-req-url.R
+++ b/tests/testthat/test-req-url.R
@@ -26,6 +26,8 @@ test_that("can append multiple components", {
 
 test_that("can handle empty path", {
   req <- request("http://example.com/x")
+  expect_equal(req_url_path(req)$url, "http://example.com")
+  expect_equal(req_url_path_append(req)$url, "http://example.com/x")
   expect_equal(req_url_path(req, NULL)$url, "http://example.com")
   expect_equal(req_url_path_append(req, NULL)$url, "http://example.com/x")
 })

--- a/tests/testthat/test-req-url.R
+++ b/tests/testthat/test-req-url.R
@@ -24,6 +24,12 @@ test_that("can append multiple components", {
   expect_equal(req_url_path_append(req, "a", "b")$url, "http://example.com/x/a/b")
 })
 
+test_that("can handle empty path", {
+  req <- request("http://example.com/x")
+  expect_equal(req_url_path(req, NULL)$url, "http://example.com")
+  expect_equal(req_url_path_append(req, NULL)$url, "http://example.com/x")
+})
+
 test_that("can set query params", {
   req <- request("http://example.com/")
   expect_equal(req_url_query(req, a = 1, b = 2)$url, "http://example.com/?a=1&b=2")


### PR DESCRIPTION
Before this PR they errored with `argument is of length zero`. Now `req_url_path_append(req, NULL)` works.