### PR TITLE
Consider refresh token for cached results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_oauth_refresh()` now respects the `refresh_token` for caching (@mgirlich, #178).
+
 # httr2 0.2.2
 
 * `curl_translate()` can now handle curl copied from Chrome developer tools

--- a/R/oauth-flow-refresh.R
+++ b/R/oauth-flow-refresh.R
@@ -33,7 +33,7 @@ req_oauth_refresh <- function(req, client,
     scope = scope,
     token_params = token_params
   )
-  cache <- cache_mem(client, NULL)
+  cache <- cache_mem(client, refresh_token)
 
   req_oauth(req, "oauth_flow_refresh", params, cache = cache)
 }

--- a/tests/testthat/test-oauth-flow-refresh.R
+++ b/tests/testthat/test-oauth-flow-refresh.R
@@ -1,0 +1,29 @@
+test_that("cache considers refresh_token", {
+  client <- oauth_client("example", "https://example.com/get_token")
+  req <- request("https://example.com")
+
+  # create 2 requests with different refresh token
+  req1 <- req %>%
+    req_oauth_refresh(client, refresh_token = "rt1")
+  req2 <- req %>%
+    req_oauth_refresh(client, refresh_token = "rt2")
+
+  # cache must be empty
+  expect_equal(req1$policies$auth_oauth$cache$get(), NULL)
+  expect_equal(req2$policies$auth_oauth$cache$get(), NULL)
+
+  # simulate that we made a request and got back a token
+  token <- oauth_token(
+    access_token = "a",
+    token_type = "bearer",
+    expires_in = NULL,
+    refresh_token = "rt1",
+    .date = Sys.time()
+  )
+  # ... that is now cached
+  req1$policies$auth_oauth$cache$set(token)
+
+  # req1 cache must be filled, but req2 cache still be empty
+  expect_equal(req1$policies$auth_oauth$cache$get(), token)
+  expect_equal(req2$policies$auth_oauth$cache$get(), NULL)
+})


### PR DESCRIPTION
Fixes #178.
@hadley The same might need to be done in

* `req_oauth_client_credentials()` (with `token_params`)
* `req_oauth_bearer_jwt()`

but I don't know much about OAuth so maybe you know this better.