### PR TITLE
add skip_if_offline() to network dependent tests

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -12,6 +12,7 @@ request_test <- function(template = "/get", ...) {
 }
 
 request_httpbin <- function(template, ...) {
+  testthat::skip_if_offline("https://httpbin.org")
   req <- request("https://httpbin.org")
   req <- req_template(req, template, ..., .env = caller_env())
   req

--- a/tests/testthat/test-req-body.R
+++ b/tests/testthat/test-req-body.R
@@ -14,6 +14,8 @@ test_that("can send file", {
 })
 
 test_that("can send string", {
+  skip_if_offline()
+
   resp <- request_httpbin("/post") %>%
     req_body_raw("test") %>%
     req_perform()
@@ -82,6 +84,7 @@ test_that("req_body_form() and req_body_multipart() accept list() with warning",
 
 test_that("can upload file with multipart", {
   skip_on_os("windows") # fails due to line ending difference
+  skip_if_offline()
 
   path <- tempfile()
   writeLines("this is a test", path)

--- a/tests/testthat/test-req-body.R
+++ b/tests/testthat/test-req-body.R
@@ -14,8 +14,6 @@ test_that("can send file", {
 })
 
 test_that("can send string", {
-  skip_if_offline()
-
   resp <- request_httpbin("/post") %>%
     req_body_raw("test") %>%
     req_perform()
@@ -84,7 +82,6 @@ test_that("req_body_form() and req_body_multipart() accept list() with warning",
 
 test_that("can upload file with multipart", {
   skip_on_os("windows") # fails due to line ending difference
-  skip_if_offline()
 
   path <- tempfile()
   writeLines("this is a test", path)


### PR DESCRIPTION
Fedora requires all software to build through a build system that does not have network access for security and predictability reasons. We still want to run as many tests as possible though, so this change adds the "skip_if_offline()" check from testthat to the two testthat tests in httr2 which call request_httpbin() and thus would need network access to succeed.

I did not pass an option to skip_if_offline() to check if httpbin specifically was reachable, though, if preferred, that would be easy enough to do.