### PR TITLE
Complete sentence in `throttle_status()` description

### DIFF
--- a/R/req-throttle.R
+++ b/R/req-throttle.R
@@ -4,7 +4,7 @@
 #' Use `req_throttle()` to ensure that repeated calls to [req_perform()] never
 #' exceed a specified rate.
 #'
-#' Call `throttle_status()` to see the
+#' Call `throttle_status()` to see the status.
 #'
 #' @inheritParams req_perform
 #' @param rate Maximum rate, i.e. maximum number of requests per second.

--- a/man/req_throttle.Rd
+++ b/man/req_throttle.Rd
@@ -27,7 +27,7 @@ A modified HTTP \link{request}.
 Use \code{req_throttle()} to ensure that repeated calls to \code{\link[=req_perform]{req_perform()}} never
 exceed a specified rate.
 
-Call \code{throttle_status()} to see the
+Call \code{throttle_status()} to see the status.
 }
 \examples{
 # Ensure we never send more than 30 requests a minute


### PR DESCRIPTION
Closes #219

Similar to #212, should compare before merging.