### PR TITLE
Fix print for parsed queries w/ curly brackets (#241)

### DIFF
--- a/R/url.R
+++ b/R/url.R
@@ -144,7 +144,7 @@ url_build <- function(url) {
     url$scheme, if (!is.null(url$scheme)) ":",
     if (!is.null(url$scheme) || !is.null(authority)) "//",
     authority, url$path,
-    if (!is.null(query)) prefix("?", utils::URLdecode(query)),
+    prefix("?", query),
     prefix("#", url$fragment)
   )
 }

--- a/R/url.R
+++ b/R/url.R
@@ -100,7 +100,9 @@ print.httr2_url <- function(x, ...) {
   if (!is.null(x$query)) {
     cli::cli_li("{.field query}: ")
     id <- cli::cli_ul()
-    cli::cli_li(paste0("  {.field ", names(x$query), "}: ", x$query))
+    # escape curly brackets for cli by replacing single with double brackets
+    query_vals <- gsub("\\{", "{{", gsub("\\}", "}}", x$query))
+    cli::cli_li(paste0("  {.field ", names(x$query), "}: ", query_vals))
     cli::cli_end(id)
   }
   if (!is.null(x$fragment)) {

--- a/R/url.R
+++ b/R/url.R
@@ -144,7 +144,7 @@ url_build <- function(url) {
     url$scheme, if (!is.null(url$scheme)) ":",
     if (!is.null(url$scheme) || !is.null(authority)) "//",
     authority, url$path,
-    prefix("?", query),
+    if (!is.null(query)) prefix("?", utils::URLdecode(query)),
     prefix("#", url$fragment)
   )
 }

--- a/tests/testthat/_snaps/url.md
+++ b/tests/testthat/_snaps/url.md
@@ -1,9 +1,9 @@
 # can print all url details
 
     Code
-      url_parse("http://user:pass@example.com:80/path?a=1&b=2#frag")
+      url_parse("http://user:pass@example.com:80/path?a=1&b=2&c={1{2}3}#frag")
     Message
-      <httr2_url> http://user:pass@example.com:80/path?a=1&b=2#frag
+      <httr2_url> http://user:pass@example.com:80/path?a=1&b=2&c={1{2}3}#frag
       * scheme: http
       * hostname: example.com
       * username: user
@@ -13,5 +13,6 @@
       * query:
         * a: 1
         * b: 2
+        * c: {1{2}3}
       * fragment: frag
 

--- a/tests/testthat/_snaps/url.md
+++ b/tests/testthat/_snaps/url.md
@@ -3,7 +3,7 @@
     Code
       url_parse("http://user:pass@example.com:80/path?a=1&b=2&c={1{2}3}#frag")
     Message
-      <httr2_url> http://user:pass@example.com:80/path?a=1&b=2&c={1{2}3}#frag
+      <httr2_url> http://user:pass@example.com:80/path?a=1&b=2&c=%7B1%7B2%7D3%7D#frag
       * scheme: http
       * hostname: example.com
       * username: user

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -22,6 +22,7 @@ test_that("can round trip urls", {
     "http://google.com/path?a=1&b=2",
     "http://google.com:80/path?a=1&b=2",
     "http://google.com:80/path?a=1&b=2#frag",
+    "http://google.com:80/path?a=1&b=2&c={1{2}3}#frag",
     "http://user@google.com:80/path?a=1&b=2",
     "http://user:pass@google.com:80/path?a=1&b=2",
     "svn+ssh://my.svn.server/repo/trunk"
@@ -32,7 +33,7 @@ test_that("can round trip urls", {
 
 test_that("can print all url details", {
   expect_snapshot(
-    url_parse("http://user:pass@example.com:80/path?a=1&b=2#frag")
+    url_parse("http://user:pass@example.com:80/path?a=1&b=2&c={1{2}3}#frag")
   )
 })
 

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -22,7 +22,7 @@ test_that("can round trip urls", {
     "http://google.com/path?a=1&b=2",
     "http://google.com:80/path?a=1&b=2",
     "http://google.com:80/path?a=1&b=2#frag",
-    "http://google.com:80/path?a=1&b=2&c={1{2}3}#frag",
+    "http://google.com:80/path?a=1&b=2&c=%7B1%7B2%7D3%7D#frag",
     "http://user@google.com:80/path?a=1&b=2",
     "http://user:pass@google.com:80/path?a=1&b=2",
     "svn+ssh://my.svn.server/repo/trunk"


### PR DESCRIPTION
Following [the cli package docs](https://cli.r-lib.org/reference/inline-markup.html?q=escapin#escaping-and-) on escaping brackets, here is the pull request for #241.