### PR TITLE
Simplify dots_to_path helper

### DIFF
--- a/R/req-url.R
+++ b/R/req-url.R
@@ -79,9 +79,6 @@ req_url_path_append <- function(req, ...) {
 dots_to_path <- function(...) {
   path <- paste(c(...), collapse = "/")
   # Ensure we don't add duplicate /s
-  if (path != "" && !grepl("^/", path)) {
-    path <- paste0("/", path)
-  }
-
-  path
+  # NB: also keeps "" unchanged.
+  sub("^([^/])", "/\\1", path)
 }


### PR DESCRIPTION
Initial idea: switch `grepl("^/", path)` to `startsWith(path, "/")`.

But went further to just eliminate the branching entirely. `path` should not be expensive to overwrite.

Basic testing:

```r
dots_to_path(NA_character_)
# [1] "/NA"
dots_to_path(character())
# [1] ""
dots_to_path("a")
# [1] "/a"
dots_to_path("a", "b")
# [1] "/a/b"
dots_to_path()
# [1] ""
dots_to_path("", "a", "b")
# [1] "/a/b"
dots_to_path("/a/b")
# [1] "/a/b"
```