### PR TITLE
Fix typo in example_url() docs

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -13,8 +13,7 @@ request_test <- function(template = "/get", ...) {
 example_url <- function() {
   check_installed("webfakes")
 
-  env_cache(
-    the, "test_app",
+  env_cache(the, "test_app",
     webfakes::new_app_process(
       webfakes::httpbin_app(),
       opts = webfakes::server_opts(num_threads = 2)

--- a/R/test.R
+++ b/R/test.R
@@ -4,7 +4,7 @@ request_test <- function(template = "/get", ...) {
   req
 }
 
-#' URL too a local server that's useful for tests and examples
+#' URL to a local server that's useful for tests and examples
 #'
 #' Requires the webfakes package to be installed.
 #'
@@ -13,7 +13,8 @@ request_test <- function(template = "/get", ...) {
 example_url <- function() {
   check_installed("webfakes")
 
-  env_cache(the, "test_app",
+  env_cache(
+    the, "test_app",
     webfakes::new_app_process(
       webfakes::httpbin_app(),
       opts = webfakes::server_opts(num_threads = 2)

--- a/man/example_url.Rd
+++ b/man/example_url.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/test.R
 \name{example_url}
 \alias{example_url}
-\title{URL too a local server that's useful for tests and examples}
+\title{URL to a local server that's useful for tests and examples}
 \usage{
 example_url()
 }


### PR DESCRIPTION
Another one I ran across, I swear I'm not hunting for them 🤠 