### PR TITLE
Support multi-line cmd in `curl_translate()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* `curl_translate()` now works with multiline commands from the clipboard
+  (@mgirlich, #254).
+
 * New `resp_has_body()` returns a `TRUE` or `FALSE` depending on whether
   or not the response has a body (#205).
 

--- a/R/curl.R
+++ b/R/curl.R
@@ -28,6 +28,7 @@ curl_translate <- function(cmd) {
     if (is_interactive() && is_installed("clipr")) {
       clip <- TRUE
       cmd <- clipr::read_clip()
+      cmd <- paste0(cmd, collapse = "\n")
     } else {
       abort("Must supply `cmd`")
     }

--- a/tests/testthat/_snaps/curl.md
+++ b/tests/testthat/_snaps/curl.md
@@ -63,3 +63,26 @@
         req_body_raw("abcdef", "text/plain") %>% 
         req_perform()
 
+# can read from clipboard
+
+    Code
+      curl_translate()
+    Message
+      v Copying to clipboard:
+    Output
+      request("http://example.com") %>% 
+        req_headers(
+          A = "1",
+          B = "2",
+        ) %>% 
+        req_perform()
+    Code
+      clipr::read_clip()
+    Output
+      [1] "request(\"http://example.com\") %>% "
+      [2] "  req_headers("                      
+      [3] "    A = \"1\","                      
+      [4] "    B = \"2\","                      
+      [5] "  ) %>% "                            
+      [6] "  req_perform()"                     
+

--- a/tests/testthat/test-curl.R
+++ b/tests/testthat/test-curl.R
@@ -124,10 +124,11 @@ test_that("can evaluate simple calls", {
 })
 
 test_that("can read from clipboard", {
+  skip_on_ci()
   skip_if_not_installed("clipr")
   withr::local_envvar(CLIPR_ALLOW = TRUE)
 
-  old_clip <- clipr::read_clip()
+  old_clip <- suppressWarnings(clipr::read_clip())
   withr::defer(clipr::write_clip(old_clip))
   rlang::local_interactive()
 

--- a/tests/testthat/test-curl.R
+++ b/tests/testthat/test-curl.R
@@ -133,16 +133,9 @@ test_that("can read from clipboard", {
   rlang::local_interactive()
 
   clipr::write_clip("curl 'http://example.com' \\\n -H 'A: 1' \\\n -H 'B: 2'")
-  request <- c(
-  'request("http://example.com") %>% ',
-  "  req_headers(",
-  '    A = "1",',
-  '    B = "2",',
-  "  ) %>% ",
-  "  req_perform()"
-  )
-  out <- suppressMessages(curl_translate())
-  expect_equal(trimws(out), structure(paste0(request, collapse = "\n"), class = "httr2_cmd"))
-  # also writes to clip
-  expect_equal(clipr::read_clip(), request)
+  expect_snapshot({
+    curl_translate()
+    # also writes to clip
+    clipr::read_clip()
+  })
 })

--- a/tests/testthat/test-curl.R
+++ b/tests/testthat/test-curl.R
@@ -141,7 +141,8 @@ test_that("can read from clipboard", {
   "  ) %>% ",
   "  req_perform()"
   )
-  expect_equal(suppressMessages(curl_translate()), structure(paste0(c(request, ""), collapse = "\n"), class = "httr2_cmd"))
+  out <- suppressMessages(curl_translate())
+  expect_equal(trimws(out), structure(paste0(request, collapse = "\n"), class = "httr2_cmd"))
   # also writes to clip
   expect_equal(clipr::read_clip(), request)
 })

--- a/tests/testthat/test-curl.R
+++ b/tests/testthat/test-curl.R
@@ -124,10 +124,13 @@ test_that("can evaluate simple calls", {
 })
 
 test_that("can read from clipboard", {
+  # need to skip on CI as can't read from clipboard there on Linux
   skip_on_ci()
   skip_if_not_installed("clipr")
+  # need to set env var so that `read/write_clip()` works in non-interactive mode
   withr::local_envvar(CLIPR_ALLOW = TRUE)
 
+  # suppress warning because the clipboard might contain no readable text
   old_clip <- suppressWarnings(clipr::read_clip())
   withr::defer(clipr::write_clip(old_clip))
   rlang::local_interactive()

--- a/tests/testthat/test-curl.R
+++ b/tests/testthat/test-curl.R
@@ -125,6 +125,8 @@ test_that("can evaluate simple calls", {
 
 test_that("can read from clipboard", {
   skip_if_not_installed("clipr")
+  withr::local_envvar(CLIPR_ALLOW = TRUE)
+
   old_clip <- clipr::read_clip()
   withr::defer(clipr::write_clip(old_clip))
   rlang::local_interactive()
@@ -138,7 +140,7 @@ test_that("can read from clipboard", {
   "  ) %>% ",
   "  req_perform()"
   )
-  expect_equal(curl_translate(), structure(paste0(c(request, ""), collapse = "\n"), class = "httr2_cmd"))
+  expect_equal(suppressMessages(curl_translate()), structure(paste0(c(request, ""), collapse = "\n"), class = "httr2_cmd"))
   # also writes to clip
   expect_equal(clipr::read_clip(), request)
 })


### PR DESCRIPTION
Fixes #254.