### PR TITLE
Detect a non-binary body better

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* `req_dry_run()` and `req_perform()` now print a human readable body in more
+  cases (@mgirlich, #91).
+
 * `curl_translate()` now works with multiline commands from the clipboard
   (@mgirlich, #254).
 

--- a/R/req-options.R
+++ b/R/req-options.R
@@ -187,17 +187,14 @@ req_verbose <- function(req,
 # helpers -----------------------------------------------------------------
 
 verbose_message <- function(prefix, x, type = "raw") {
-  if (any(x > 128) && !type %in% c("json", "form")) {
-    # This doesn't handle unicode, but it seems like most output
-    # will be compressed in some way, so displaying bodies is unlikely
-    # to be useful anyway.
-    lines <- paste0(length(x), " bytes of binary data")
-  } else {
+  if (type %in% c("json", "form")) {
     x <- readBin(x, character())
     if (type == "form") {
       x <- curl::curl_unescape(x)
     }
     lines <- unlist(strsplit(x, "\r?\n", useBytes = TRUE))
+  } else {
+    lines <- paste0(length(x), " bytes of binary data")
   }
   cli::cat_line(prefix, lines)
 }

--- a/R/req-perform.R
+++ b/R/req-perform.R
@@ -214,7 +214,10 @@ req_dry_run <- function(req, quiet = FALSE, redact_headers = TRUE) {
   if (!quiet) {
     debug <- function(type, msg) {
       if (type == 2L) verbose_header("", msg, redact = redact_headers)
-      if (type == 4L) verbose_message("", msg)
+      if (type == 4L) {
+        # FIXME check req content type to better detect a binary body - needs #190
+        verbose_message("", msg, type = req$body$type %||% "raw")
+      }
     }
     req <- req_options(req, debugfunction = debug, verbose = TRUE)
   }

--- a/tests/testthat/_snaps/req-options.md
+++ b/tests/testthat/_snaps/req-options.md
@@ -7,7 +7,7 @@
     -> Accept-Encoding: gzip
     -> Content-Length: 17
     -> 
-    >> This is some text
+    >> 17 bytes of binary data
 
 # req_proxy gives helpful errors
 

--- a/tests/testthat/_snaps/req-perform.md
+++ b/tests/testthat/_snaps/req-perform.md
@@ -26,9 +26,9 @@
 # req_dry_run() shows body
 
     Code
-      request("http://example.com") %>% req_headers(`Accept-Encoding` = "gzip") %>%
-        req_body_json(list(x = 1, y = TRUE, z = "c")) %>% req_user_agent("test") %>%
-        req_dry_run()
+      req <- request("http://example.com") %>% req_headers(`Accept-Encoding` = "gzip") %>%
+        req_user_agent("test")
+      req %>% req_body_json(list(x = 1, y = TRUE, z = "c")) %>% req_dry_run()
     Output
       POST / HTTP/1.1
       Host: example.com
@@ -39,6 +39,30 @@
       Content-Length: 24
       
       {"x":1,"y":true,"z":"c"}
+    Code
+      req %>% req_body_json(list(x = "Cenário 1")) %>% req_dry_run()
+    Output
+      POST / HTTP/1.1
+      Host: example.com
+      User-Agent: test
+      Accept: */*
+      Accept-Encoding: gzip
+      Content-Type: application/json
+      Content-Length: 18
+      
+      {"x":"Cenário 1"}
+    Code
+      req %>% req_body_form(x = "Cenário 1") %>% req_dry_run()
+    Output
+      POST / HTTP/1.1
+      Host: example.com
+      User-Agent: test
+      Accept: */*
+      Accept-Encoding: gzip
+      Content-Type: application/x-www-form-urlencoded
+      Content-Length: 18
+      
+      x=Cenário 1
 
 # authorization headers are redacted
 

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -90,10 +90,21 @@ test_that("req_dry_run() shows body", {
   skip_if_not(getRversion() >= "3.5")
 
   expect_snapshot({
-    request("http://example.com") %>%
+    req <- request("http://example.com") %>%
       req_headers(`Accept-Encoding` = "gzip") %>%
+      req_user_agent("test")
+
+    req %>%
       req_body_json(list(x = 1, y = TRUE, z = "c")) %>%
-      req_user_agent("test") %>%
+      req_dry_run()
+
+    # body is printed for JSON and form
+    req %>%
+      req_body_json(list(x = "Cenário 1")) %>%
+      req_dry_run()
+
+    req %>%
+      req_body_form(x = "Cenário 1") %>%
       req_dry_run()
   })
 })


### PR DESCRIPTION
Closes #91.
The type resp. content type of the request/response body provides a good indicator whether the body contains binary data or not.