### PR TITLE
Add `page_size` and `set_page_size` arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* New `req_paginate()` and `paginate_req_perform()` to easily request paginated
+  APIs (@mgirlich, #8).
+
 * New `oauth_cache_path()` returns the path that httr2 uses for caching OAuth
   tokens. Additionally, you can now change the cache location by setting the
   `HTTR2_OAUTH_CACHE` env var.

--- a/R/paginate.R
+++ b/R/paginate.R
@@ -38,7 +38,6 @@
 #'   ceiling(total / page_size)
 #' }
 #' request("https://pokeapi.co/api/v2/pokemon") %>%
-#'   req_url_query(limit = page_size) %>%
 #'   req_paginate_next_url(
 #'     next_url = function(resp) resp_body_json(resp)[["next"]],
 #'     page_size = 150,
@@ -97,12 +96,13 @@ req_paginate <- function(req,
 #' @export
 #'
 #' @examples
-#' page_size <- 150
-#'
 #' req_pokemon <- request("https://pokeapi.co/api/v2/pokemon") %>%
-#'   req_url_query(limit = page_size) %>%
 #'   req_paginate_next_url(
 #'     next_url = function(resp) resp_body_json(resp)[["next"]],
+#'     page_size = 150,
+#'     set_page_size = function(req, page_size) {
+#'       req_url_query(req, limit = page_size)
+#'     },
 #'     n_pages = function(resp) {
 #'       total <- resp_body_json(resp)$count
 #'       ceiling(total / page_size)

--- a/man/paginate_req_perform.Rd
+++ b/man/paginate_req_perform.Rd
@@ -25,12 +25,13 @@ A list of responses.
 Perform a paginated request
 }
 \examples{
-page_size <- 150
-
 req_pokemon <- request("https://pokeapi.co/api/v2/pokemon") \%>\%
-  req_url_query(limit = page_size) \%>\%
   req_paginate_next_url(
     next_url = function(resp) resp_body_json(resp)[["next"]],
+    page_size = 150,
+    set_page_size = function(req, page_size) {
+      req_url_query(req, limit = page_size)
+    },
     n_pages = function(resp) {
       total <- resp_body_json(resp)$count
       ceiling(total / page_size)

--- a/man/req_paginate.Rd
+++ b/man/req_paginate.Rd
@@ -7,13 +7,38 @@
 \alias{req_paginate_token}
 \title{Pagination}
 \usage{
-req_paginate(req, next_request, n_pages = NULL)
+req_paginate(
+  req,
+  next_request,
+  page_size = NULL,
+  set_page_size = NULL,
+  n_pages = NULL
+)
 
-req_paginate_next_url(req, next_url, n_pages = NULL)
+req_paginate_next_url(
+  req,
+  next_url,
+  page_size = NULL,
+  set_page_size = NULL,
+  n_pages = NULL
+)
 
-req_paginate_offset(req, offset, page_size, n_pages = NULL)
+req_paginate_offset(
+  req,
+  offset,
+  page_size,
+  set_page_size = NULL,
+  n_pages = NULL
+)
 
-req_paginate_token(req, set_token, next_token, n_pages = NULL)
+req_paginate_token(
+  req,
+  set_token,
+  next_token,
+  page_size = NULL,
+  set_page_size = NULL,
+  n_pages = NULL
+)
 }
 \arguments{
 \item{req}{A \link{request}.}
@@ -25,17 +50,21 @@ original request and the response) and returns:
 \item \code{NULL} if there is no next page.
 }}
 
+\item{page_size}{A whole number that specifies the page size i.e. the number
+of elements per page.}
+
+\item{set_page_size}{A function applies the page size to the request. It must
+have the arguments \code{req} and \code{page_size}.}
+
 \item{n_pages}{A function that extracts the total number of pages from
-the \link{response}.}
+the \link{response}. If the \code{page_size} argument is provided, the \code{page_size}
+variable can be used in this function.}
 
 \item{next_url}{A function that extracts the url to the next page from the
 \link{response}.}
 
 \item{offset}{A function that applies the new offset to the request. It takes
 two arguments: a \link{request} and an integer offset.}
-
-\item{page_size}{A whole number that specifies the page size i.e. the number
-of elements per page.}
 
 \item{set_token}{A function that applies the new token to the request. It
 takes two arguments: a \link{request} and the new token.}
@@ -61,16 +90,20 @@ that is used to describe the next page.
 }
 }
 \examples{
-page_size <- 150
-
+calculate_n_pages <- function(resp) {
+  total <- resp_body_json(resp)$count
+  # the page size will be injected from the `page_size` argument of `req_paginate()`
+  ceiling(total / page_size)
+}
 request("https://pokeapi.co/api/v2/pokemon") \%>\%
   req_url_query(limit = page_size) \%>\%
   req_paginate_next_url(
     next_url = function(resp) resp_body_json(resp)[["next"]],
-    n_pages = function(resp) {
-      total <- resp_body_json(resp)$count
-      ceiling(total / page_size)
-    }
+    page_size = 150,
+    set_page_size = function(req, page_size) {
+      req_url_query(req, limit = page_size)
+    },
+    n_pages = calculate_n_pages
   )
 }
 \seealso{

--- a/man/req_paginate.Rd
+++ b/man/req_paginate.Rd
@@ -96,7 +96,6 @@ calculate_n_pages <- function(resp) {
   ceiling(total / page_size)
 }
 request("https://pokeapi.co/api/v2/pokemon") \%>\%
-  req_url_query(limit = page_size) \%>\%
   req_paginate_next_url(
     next_url = function(resp) resp_body_json(resp)[["next"]],
     page_size = 150,

--- a/tests/testthat/_snaps/paginate.md
+++ b/tests/testthat/_snaps/paginate.md
@@ -16,6 +16,27 @@
       Error in `req_paginate()`:
       ! `next_request` must have the arguments `req` and `resp`, not `req`.
     Code
+      req_paginate(req, next_request, page_size = -1)
+    Condition
+      Error in `req_paginate()`:
+      ! `page_size` must be a whole number larger than or equal to 1 or `NULL`, not the number -1.
+    Code
+      req_paginate(req, next_request, page_size = 1, set_page_size = "a")
+    Condition
+      Error in `req_paginate()`:
+      ! `set_page_size` must be a function or `NULL`, not the string "a".
+    Code
+      req_paginate(req, next_request, page_size = 1, set_page_size = function(req)
+      req)
+    Condition
+      Error in `req_paginate()`:
+      ! `set_page_size` must have the arguments `req` and `page_size`, not `req`.
+    Code
+      req_paginate(req, next_request, set_page_size = function(req, page_size) req)
+    Condition
+      Error in `req_paginate()`:
+      ! Must provide a `page_size` together with `set_page_size`.
+    Code
       req_paginate(req, next_request, n_pages = "a")
     Condition
       Error in `req_paginate()`:


### PR DESCRIPTION
To avoid having to specify the page size multiple times.

Before

```r
request("https://pokeapi.co/api/v2/pokemon") %>%
  req_url_query(limit = 150) %>%
  req_paginate_offset(
    offset = \(req, offset) req_url_query(req, offset = offset),
    page_size = 150,
    n_pages = function(resp) {
      total <- resp_body_json(resp)$count
      ceiling(total / 150)
    }
  )
```

After

```r
request("https://pokeapi.co/api/v2/pokemon") %>%
  req_paginate_offset(
    offset = \(req, offset) req_url_query(req, offset = offset),
    page_size = 150,
    set_page_size = \(req, page_size) req_url_query(req, limit = page_size),
    n_pages = function(resp) {
      total <- resp_body_json(resp)$count
      # `page_size` can be used in this function
      ceiling(total / page_size)
    }
  )
```