### PR TITLE
Fix unit tests on Workbench

### DIFF
--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -258,7 +258,7 @@ normalize_redirect_uri <- function(redirect_uri,
     check_installed("httpuv", "desktop OAuth")
     if (is_hosted_session()) {
       cli::cli_abort(
-        "Can't use localhost {.arg redirect_uri} in a hosted environment",
+        "Can't use localhost {.arg redirect_uri} in a hosted environment.",
         call = error_call
       )
     }

--- a/tests/testthat/_snaps/oauth-flow-auth-code.md
+++ b/tests/testthat/_snaps/oauth-flow-auth-code.md
@@ -4,7 +4,7 @@
       oauth_flow_auth_code(client, "http://localhost")
     Condition
       Error in `oauth_flow_auth_code()`:
-      ! Can't use localhost `redirect_uri` in a hosted environment
+      ! Can't use localhost `redirect_uri` in a hosted environment.
 
 # old args are deprecated
 

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -51,11 +51,17 @@ test_that("bare authorisation codes can be input manually", {
 # normalize_redirect_uri --------------------------------------------------
 
 test_that("adds port to localhost url", {
+  # Allow tests to run when is_hosted_session() is TRUE.
+  local_mocked_bindings(is_hosted_session = function() FALSE)
+
   redirect <- normalize_redirect_uri("http://localhost")
   expect_false(is.null(url_parse(redirect$uri)$port))
 })
 
 test_that("old args are deprecated", {
+  # Allow tests to run when is_hosted_session() is TRUE.
+  local_mocked_bindings(is_hosted_session = function() FALSE)
+
   expect_snapshot(
     redirect <- normalize_redirect_uri("http://localhost", port = 1234)
   )
@@ -70,6 +76,14 @@ test_that("old args are deprecated", {
     redirect <- normalize_redirect_uri("http://x.com", host_ip = "y.com")
   )
 
+})
+
+test_that("hosted sessions error on localhost redirects", {
+  local_mocked_bindings(is_hosted_session = function() TRUE)
+  expect_error(
+    normalize_redirect_uri("http://localhost"),
+    "Can't use localhost `redirect_uri` in a hosted environment"
+  )
 })
 
 # ouath_flow_auth_code_parse ----------------------------------------------

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -78,14 +78,6 @@ test_that("old args are deprecated", {
 
 })
 
-test_that("hosted sessions error on localhost redirects", {
-  local_mocked_bindings(is_hosted_session = function() TRUE)
-  expect_error(
-    normalize_redirect_uri("http://localhost"),
-    "Can't use localhost `redirect_uri` in a hosted environment"
-  )
-})
-
 # ouath_flow_auth_code_parse ----------------------------------------------
 
 test_that("forwards oauth error", {


### PR DESCRIPTION
Previously these tests would fail because `is_hosted_session()` returns `TRUE` on these platforms and yields a different error. This commit skips these tests in hosted sessions instead.