### PR TITLE
Simplify mocking of base::readline()

### DIFF
--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -413,7 +413,7 @@ is_hosted_session <- function() {
 }
 
 oauth_flow_auth_code_read <- function(state) {
-  code <- trimws(read_line("Enter authorization code: "))
+  code <- trimws(readline("Enter authorization code: "))
   # We support two options here:
   #
   # 1) The original {gargle} style, where the user copy & pastes a
@@ -427,7 +427,7 @@ oauth_flow_auth_code_read <- function(state) {
    error = function(e) {
     list(
       code = code,
-      state = trimws(read_line("Enter state parameter: "))
+      state = trimws(readline("Enter state parameter: "))
     )
   })
   if (!identical(result$state, state)) {
@@ -436,7 +436,5 @@ oauth_flow_auth_code_read <- function(state) {
   result$code
 }
 
-# base::readline() wrapper so we can mock user input during testing.
-read_line <- function(prompt = "") {
-  readline(prompt)
-}
+# Make base::readline() mockable
+readline <- NULL

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -25,7 +25,7 @@ test_that("JSON-encoded authorisation codes can be input manually", {
   input <- list(state = state, code = "abc123")
   encoded <- openssl::base64_encode(jsonlite::toJSON(input))
   local_mocked_bindings(
-    read_line = function(prompt = "") encoded
+    readline = function(prompt = "") encoded
   )
   expect_equal(oauth_flow_auth_code_read(state), "abc123")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -35,7 +35,7 @@ test_that("bare authorisation codes can be input manually", {
   state <- base64_url_rand(32)
   sent_code <- FALSE
   local_mocked_bindings(
-    read_line = function(prompt = "") {
+    readline = function(prompt = "") {
       if (sent_code) {
         state
       } else {


### PR DESCRIPTION
Using newly discovered technique

cc @mgirlich 