### PR TITLE
Update phantom httr references from httr to httr2.

### DIFF
--- a/R/req-headers.R
+++ b/R/req-headers.R
@@ -6,7 +6,7 @@
 #' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Name-value pairs of headers
 #'   and their values.
 #'
-#'   * Use `NULL` to reset a value to httr's default
+#'   * Use `NULL` to reset a value to httr2's default
 #'   * Use `""` to remove a header
 #'   * Use a character vector to repeat a header.
 #' @param .redact Headers to redact. If `NULL`, the default, the added headers

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ httr2 (pronounced hitter2) is a ground-up rewrite of [httr](https://httr.r-lib.o
 
 ## Installation
 
-You can install httr from CRAN with:
+You can install httr2 from CRAN with:
 
 ``` r
 install.packages("httr2")

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and more).
 
 ## Installation
 
-You can install httr from CRAN with:
+You can install httr2 from CRAN with:
 
 ``` r
 install.packages("httr2")
@@ -76,7 +76,7 @@ And see exactly what httr2 will send to the server with `req_dry_run()`:
 req %>% req_dry_run()
 #> GET / HTTP/1.1
 #> Host: r-project.org
-#> User-Agent: httr2/0.2.3.9000 r-curl/5.1.0 libcurl/8.1.2
+#> User-Agent: httr2/0.2.3.9000 r-curl/5.1.0 libcurl/8.3.0
 #> Accept: */*
 #> Accept-Encoding: deflate, gzip
 ```

--- a/man/req_headers.Rd
+++ b/man/req_headers.Rd
@@ -12,7 +12,7 @@ req_headers(.req, ..., .redact = NULL)
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Name-value pairs of headers
 and their values.
 \itemize{
-\item Use \code{NULL} to reset a value to httr's default
+\item Use \code{NULL} to reset a value to httr2's default
 \item Use \code{""} to remove a header
 \item Use a character vector to repeat a header.
 }}


### PR DESCRIPTION
The libcurl version updated when I reknitted README.Rmd. It made me notice that you'll want to be sure to reknit the README after the version gets bumped to pick up the proper version in the User-Agent, which I don't think is a normal part of the checklist.