### PR TITLE
Move oauth vignette out of articles.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 * `req_template()` now works when you have a bare `:` in a template that
   uses "uri" style (#389).
 
+* `vignette("oauth")` is now available as a package vignette, not just on the 
+  package website (@jonthegeek, #398).
+
 # httr2 1.0.0
 
 ## Function lifecycle

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -89,7 +89,7 @@ articles:
   navbar: ~
   contents:
   - articles/wrapping-apis
-  - articles/oauth
+  - oauth
 
 
 news:

--- a/vignettes/oauth.Rmd
+++ b/vignettes/oauth.Rmd
@@ -1,5 +1,10 @@
 ---
 title: "OAuth"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{oauth}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r, include = FALSE}


### PR DESCRIPTION
Closes #398.

I'm not sure if there's something not-CRAN-safe that prevents this from being here, but it seems to work locally at least.