### PR TITLE
use rstudioapi instead of readline if calling oauth_flow_auth_code() from RStudio IDE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
     vctrs (>= 0.6.3),
     withr
 Suggests:
-    askpass,
     bench,
     clipr,
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Suggests:
     jsonlite,
     knitr,
     rmarkdown,
+    rstudioapi,
     testthat (>= 3.1.8),
     tibble,
     webfakes,

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * `req_template()` now works when you have a bare `:` in a template that
   uses "uri" style (#389).
 
+* `oauth_flow_auth_code()` now uses `askpass::askpass()` instead of `readline()` 
+  when prompting the user to enter character strings (@fh-mthomson, #406).
+
 # httr2 1.0.0
 
 ## Function lifecycle

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 * `req_template()` now works when you have a bare `:` in a template that
   uses "uri" style (#389).
 
-* `oauth_flow_auth_code()` now uses `askpass::askpass()` instead of `readline()` 
-  when prompting the user to enter character strings (@fh-mthomson, #406).
+* `oauth_flow_auth_code()` now uses `rstudioapi::askForPassword()` 
+  (if in RStudio, `askpass::askpass()` otherwise) instead of `readline()` 
+  when prompting the user to enter password / auth codes (@fh-mthomson, #406).
 
 # httr2 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,8 @@
   uses "uri" style (#389).
 
 * `oauth_flow_auth_code()` now uses `rstudioapi::askForPassword()` 
-  (if in RStudio, `askpass::askpass()` otherwise) instead of `readline()` 
-  when prompting the user to enter password / auth codes (@fh-mthomson, #406).
+  (if in RStudio, `readline()` otherwise) when prompting the user to 
+  input auth codes (@fh-mthomson, #406).
 
 # httr2 1.0.0
 

--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -106,6 +106,7 @@ req_oauth_auth_code <- function(req,
                                 host_name = deprecated(),
                                 host_ip = deprecated(),
                                 port = deprecated()) {
+
   redirect <- normalize_redirect_uri(
     redirect_uri = redirect_uri,
     host_name = host_name,
@@ -138,7 +139,9 @@ oauth_flow_auth_code <- function(client,
                                  redirect_uri = oauth_redirect_uri(),
                                  host_name = deprecated(),
                                  host_ip = deprecated(),
-                                 port = deprecated()) {
+                                 port = deprecated()
+ ) {
+
   oauth_flow_check("authorization code", client, interactive = TRUE)
 
   redirect <- normalize_redirect_uri(
@@ -201,6 +204,7 @@ normalize_redirect_uri <- function(redirect_uri,
                                    host_ip = deprecated(),
                                    port = deprecated(),
                                    error_call = caller_env()) {
+
   parsed <- url_parse(redirect_uri)
 
   if (lifecycle::is_present(host_name)) {
@@ -246,6 +250,7 @@ normalize_redirect_uri <- function(redirect_uri,
     localhost = localhost,
     can_fetch_code = can_fetch_oauth_code(redirect_uri)
   )
+
 }
 
 
@@ -398,27 +403,10 @@ oauth_flow_auth_code_pkce <- function() {
   )
 }
 
-# Try to determine whether we can redirect the user's browser to a server on
-# localhost, which isn't possible if we are running on a hosted platform.
-#
-# Currently this detects RStudio Server, Posit Workbench, and Google Colab. It
-# is based on the strategy pioneered by the {gargle} package.
-is_hosted_session <- function() {
-  if (nzchar(Sys.getenv("COLAB_RELEASE_TAG"))) {
-    return(TRUE)
-  }
-  # If RStudio Server or Posit Workbench is running locally (which is possible,
-  # though unusual), it's not acting as a hosted environment.
-  Sys.getenv("RSTUDIO_PROGRAM_MODE") == "server" &&
-    !grepl("localhost", Sys.getenv("RSTUDIO_HTTP_REFERER"), fixed = TRUE)
-}
 
-is_rstudio_session <- function() {
-  !is.na(Sys.getenv("RSTUDIO_PROGRAM_MODE", unset = NA))
-}
 
 oauth_flow_auth_code_read <- function(state) {
-  code <- ask_user_prompt("Enter authorization code or URL: ")
+  code <- prompt_user("Enter authorization code or URL: ")
 
   if (is_string_url(code)) {
     # minimal setup where user copy & pastes a URL
@@ -438,7 +426,7 @@ oauth_flow_auth_code_read <- function(state) {
     # Full manual approach, where the code and state are entered
     # independently.
 
-    new_state <- ask_user_prompt("Enter state parameter: ")
+    new_state <- prompt_user("Enter state parameter: ")
   }
 
   if (!identical(state, new_state)) {

--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -419,7 +419,8 @@ is_hosted_session <- function() {
 }
 
 oauth_flow_auth_code_read <- function(state) {
-  code <- trimws(readline("Enter authorization code or URL: "))
+  check_installed("askpass")
+  code <- askpass::askpass("Enter authorization code or URL")
 
   if (is_string_url(code)) {
     # minimal setup where user copy & pastes a URL
@@ -439,7 +440,7 @@ oauth_flow_auth_code_read <- function(state) {
     # Full manual approach, where the code and state are entered
     # independently.
 
-    new_state <- trimws(readline("Enter state parameter: "))
+    new_state <- askpass::askpass("Enter state parameter")
   }
 
   if (!identical(state, new_state)) {
@@ -486,6 +487,3 @@ oauth_flow_auth_code_fetch <- function(state) {
   body <- resp_body_json(resp)
   body$code
 }
-
-# Make base::readline() mockable
-readline <- NULL

--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -140,7 +140,7 @@ oauth_flow_auth_code <- function(client,
                                  host_name = deprecated(),
                                  host_ip = deprecated(),
                                  port = deprecated()
- ) {
+) {
 
   oauth_flow_check("authorization code", client, interactive = TRUE)
 

--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -106,7 +106,6 @@ req_oauth_auth_code <- function(req,
                                 host_name = deprecated(),
                                 host_ip = deprecated(),
                                 port = deprecated()) {
-
   redirect <- normalize_redirect_uri(
     redirect_uri = redirect_uri,
     host_name = host_name,
@@ -139,9 +138,7 @@ oauth_flow_auth_code <- function(client,
                                  redirect_uri = oauth_redirect_uri(),
                                  host_name = deprecated(),
                                  host_ip = deprecated(),
-                                 port = deprecated()
-) {
-
+                                 port = deprecated()) {
   oauth_flow_check("authorization code", client, interactive = TRUE)
 
   redirect <- normalize_redirect_uri(
@@ -204,7 +201,6 @@ normalize_redirect_uri <- function(redirect_uri,
                                    host_ip = deprecated(),
                                    port = deprecated(),
                                    error_call = caller_env()) {
-
   parsed <- url_parse(redirect_uri)
 
   if (lifecycle::is_present(host_name)) {
@@ -250,7 +246,6 @@ normalize_redirect_uri <- function(redirect_uri,
     localhost = localhost,
     can_fetch_code = can_fetch_oauth_code(redirect_uri)
   )
-
 }
 
 
@@ -418,9 +413,12 @@ is_hosted_session <- function() {
     !grepl("localhost", Sys.getenv("RSTUDIO_HTTP_REFERER"), fixed = TRUE)
 }
 
+is_rstudio_session <- function() {
+  !is.na(Sys.getenv("RSTUDIO_PROGRAM_MODE", unset = NA))
+}
+
 oauth_flow_auth_code_read <- function(state) {
-  check_installed("askpass")
-  code <- askpass::askpass("Enter authorization code or URL")
+  code <- ask_user_prompt("Enter authorization code or URL: ")
 
   if (is_string_url(code)) {
     # minimal setup where user copy & pastes a URL
@@ -440,7 +438,7 @@ oauth_flow_auth_code_read <- function(state) {
     # Full manual approach, where the code and state are entered
     # independently.
 
-    new_state <- askpass::askpass("Enter state parameter")
+    new_state <- ask_user_prompt("Enter state parameter: ")
   }
 
   if (!identical(state, new_state)) {

--- a/R/oauth-flow-password.R
+++ b/R/oauth-flow-password.R
@@ -69,9 +69,21 @@ oauth_flow_password <- function(client,
 
 check_password <- function(password, call = caller_env()) {
   if (is.null(password)) {
-    check_installed("askpass", call = call)
-    password <- askpass::askpass()
+    password <- ask_user_prompt()
   }
   check_string(password, call = call)
   password
+}
+
+ask_user_prompt <- function(prompt = "Please enter your password: ") {
+  if (is_rstudio_session()) {
+    check_installed("rstudioapi")
+    result <- rstudioapi::askForPassword(prompt)
+  } else {
+    # use askpass as a fall back, which does not work when called non-interactively
+    # (including when knitting from RStudio)
+    check_installed("askpass")
+    result <- askpass::askpass(prompt)
+  }
+  result
 }

--- a/R/oauth-flow-password.R
+++ b/R/oauth-flow-password.R
@@ -80,10 +80,9 @@ ask_user_prompt <- function(prompt = "Please enter your password: ") {
     check_installed("rstudioapi")
     result <- rstudioapi::askForPassword(prompt)
   } else {
-    # use askpass as a fall back, which does not work when called non-interactively
-    # (including when knitting from RStudio)
-    check_installed("askpass")
-    result <- askpass::askpass(prompt)
+    # use readline as a fall back which works in R (or JupyterHub, see)
+    # https://github.com/r-lib/httr2/pull/410#issuecomment-1852721581
+    result <- trimws(readline(prompt))
   }
   result
 }

--- a/R/oauth-flow-password.R
+++ b/R/oauth-flow-password.R
@@ -80,8 +80,8 @@ ask_user_prompt <- function(prompt = "Please enter your password: ") {
     check_installed("rstudioapi")
     result <- rstudioapi::askForPassword(prompt)
   } else {
-    # use readline as a fall back which works in R (or JupyterHub, see)
-    # https://github.com/r-lib/httr2/pull/410#issuecomment-1852721581
+    # use readline over askpass outside of RStudio IDE since it generalizes better to
+    # JupyterHub + Google Colab, see https://github.com/r-lib/httr2/pull/410#issuecomment-1852721581
     result <- trimws(readline(prompt))
   }
   result

--- a/R/oauth-flow-password.R
+++ b/R/oauth-flow-password.R
@@ -69,20 +69,9 @@ oauth_flow_password <- function(client,
 
 check_password <- function(password, call = caller_env()) {
   if (is.null(password)) {
-    password <- ask_user_prompt()
+    password <- prompt_user()
   }
   check_string(password, call = call)
   password
 }
 
-ask_user_prompt <- function(prompt = "Please enter your password: ") {
-  if (is_rstudio_session()) {
-    check_installed("rstudioapi")
-    result <- rstudioapi::askForPassword(prompt)
-  } else {
-    # use readline over askpass outside of RStudio IDE since it generalizes better to
-    # JupyterHub + Google Colab, see https://github.com/r-lib/httr2/pull/410#issuecomment-1852721581
-    result <- trimws(readline(prompt))
-  }
-  result
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -284,7 +284,7 @@ create_progress_bar <- function(total,
 
 prompt_user <- function(prompt = "Please enter your password: ") {
   if (is_rstudio_session()) {
-    check_installed("rstudioapi")
+    check_installed("rstudioapi", reason = "to ask user for inputs.")
     result <- rstudioapi::askForPassword(prompt)
   } else {
     # use readline over askpass outside of RStudio IDE since it generalizes better to

--- a/R/utils.R
+++ b/R/utils.R
@@ -286,11 +286,14 @@ prompt_user <- function(prompt = "Please enter your password: ") {
   if (is_rstudio_session()) {
     check_installed("rstudioapi", reason = "to ask user for inputs.")
     result <- rstudioapi::askForPassword(prompt)
-  } else {
+  } else if (rlang::is_interactive()) {
     # use readline over askpass outside of RStudio IDE since it generalizes better to
     # JupyterHub + Google Colab, see https://github.com/r-lib/httr2/pull/410#issuecomment-1852721581
     result <- trimws(readline(prompt))
+  } else {
+    cli::cli_abort("Unable to obtain user input in a non-interactive session.")
   }
+
   result
 }
 

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -22,7 +22,7 @@ test_that("so-called 'hosted' sessions are detected correctly", {
 
 test_that("URL embedding authorisation code and state can be input manually", {
   local_mocked_bindings(
-    ask_user_prompt = function(prompt = "") "https://x.com?code=code&state=state"
+    prompt_user = function(prompt = "") "https://x.com?code=code&state=state"
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -32,7 +32,7 @@ test_that("JSON-encoded authorisation codes can be input manually", {
   input <- list(state = "state", code = "code")
   encoded <- openssl::base64_encode(jsonlite::toJSON(input))
   local_mocked_bindings(
-    ask_user_prompt = function(prompt = "") encoded
+    prompt_user = function(prompt = "") encoded
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -42,7 +42,7 @@ test_that("bare authorisation codes can be input manually", {
   state <- base64_url_rand(32)
   sent_code <- FALSE
   local_mocked_bindings(
-    ask_user_prompt = function(prompt = "") {
+    prompt_user = function(prompt = "") {
       if (sent_code) {
         state
       } else {

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -22,7 +22,8 @@ test_that("so-called 'hosted' sessions are detected correctly", {
 
 test_that("URL embedding authorisation code and state can be input manually", {
   local_mocked_bindings(
-    readline = function(prompt = "") "https://x.com?code=code&state=state"
+    askpass = function(prompt = "") "https://x.com?code=code&state=state",
+    .package = "askpass"
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -32,7 +33,8 @@ test_that("JSON-encoded authorisation codes can be input manually", {
   input <- list(state = "state", code = "code")
   encoded <- openssl::base64_encode(jsonlite::toJSON(input))
   local_mocked_bindings(
-    readline = function(prompt = "") encoded
+    askpass = function(prompt = "") encoded,
+    .package = "askpass"
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -42,14 +44,15 @@ test_that("bare authorisation codes can be input manually", {
   state <- base64_url_rand(32)
   sent_code <- FALSE
   local_mocked_bindings(
-    readline = function(prompt = "") {
+    askpass = function(prompt = "") {
       if (sent_code) {
         state
       } else {
         sent_code <<- TRUE
         "zyx987"
       }
-    }
+    },
+    .package = "askpass"
   )
   expect_equal(oauth_flow_auth_code_read(state), "zyx987")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -22,7 +22,7 @@ test_that("so-called 'hosted' sessions are detected correctly", {
 
 test_that("URL embedding authorisation code and state can be input manually", {
   local_mocked_bindings(
-    ask_user_prompt = function(prompt = "") "https://x.com?code=code&state=state",
+    ask_user_prompt = function(prompt = "") "https://x.com?code=code&state=state"
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -32,7 +32,7 @@ test_that("JSON-encoded authorisation codes can be input manually", {
   input <- list(state = "state", code = "code")
   encoded <- openssl::base64_encode(jsonlite::toJSON(input))
   local_mocked_bindings(
-    ask_user_prompt = function(prompt = "") encoded,
+    ask_user_prompt = function(prompt = "") encoded
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -22,8 +22,7 @@ test_that("so-called 'hosted' sessions are detected correctly", {
 
 test_that("URL embedding authorisation code and state can be input manually", {
   local_mocked_bindings(
-    askpass = function(prompt = "") "https://x.com?code=code&state=state",
-    .package = "askpass"
+    ask_user_prompt = function(prompt = "") "https://x.com?code=code&state=state",
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -33,8 +32,7 @@ test_that("JSON-encoded authorisation codes can be input manually", {
   input <- list(state = "state", code = "code")
   encoded <- openssl::base64_encode(jsonlite::toJSON(input))
   local_mocked_bindings(
-    askpass = function(prompt = "") encoded,
-    .package = "askpass"
+    ask_user_prompt = function(prompt = "") encoded,
   )
   expect_equal(oauth_flow_auth_code_read("state"), "code")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")
@@ -44,15 +42,14 @@ test_that("bare authorisation codes can be input manually", {
   state <- base64_url_rand(32)
   sent_code <- FALSE
   local_mocked_bindings(
-    askpass = function(prompt = "") {
+    ask_user_prompt = function(prompt = "") {
       if (sent_code) {
         state
       } else {
         sent_code <<- TRUE
         "zyx987"
       }
-    },
-    .package = "askpass"
+    }
   )
   expect_equal(oauth_flow_auth_code_read(state), "zyx987")
   expect_error(oauth_flow_auth_code_read("invalid"), "state does not match")

--- a/vignettes/articles/wrapping-apis.Rmd
+++ b/vignettes/articles/wrapping-apis.Rmd
@@ -507,7 +507,7 @@ set_api_key <- function(key = NULL) {
 }
 ```
 
-Using `rstudioapi` (or similar) here is good practice since you don't want to encourage the user to type their secret key into the console, as mentioned above.
+Using rstudioapi (or similar) here is good practice since you don't want to encourage the user to type their secret key into the console, as mentioned above.
 
 It's a good idea to extend `get_api_key()` to automatically use your encrypted key to make it easier to write tests:
 

--- a/vignettes/articles/wrapping-apis.Rmd
+++ b/vignettes/articles/wrapping-apis.Rmd
@@ -501,13 +501,13 @@ You can make this approach a little more user friendly by providing a helper tha
 ```{r}
 set_api_key <- function(key = NULL) {
   if (is.null(key)) {
-    key <- askpass::askpass("Please enter your API key")
+    key <- rstudioapi::askForPassword("Please enter your API key")
   }
   Sys.setenv("NYTIMES_KEY" = key)
 }
 ```
 
-Using askpass (or similar) here is good practice since you don't want to encourage the user to type their secret key into the console, as mentioned above.
+Using `rstudioapi` (or similar) here is good practice since you don't want to encourage the user to type their secret key into the console, as mentioned above.
 
 It's a good idea to extend `get_api_key()` to automatically use your encrypted key to make it easier to write tests:
 


### PR DESCRIPTION
Closes #406 

# Test plan

Running `oauth_flow_auth_code_read("state")` successfully prompts twice (initial prompt, then state) in either case described in parent issue:
1. sequential R chunks run in .Rmd 
2. knitting .Rmd

# Implementation considerations
* Initially implemented a version of using _only_ `askpass`, given broader generalizability outside of RStudio IDE; however, this doesn't scale as well off the shelf to the non-interactive use case (e.g., knitting in RStudio) - per `?askpass::askpass`:
```
By default askpass() returns NULL in non-interactive sessions. (These include knitr runs and testthat tests.) If you want to force a password prompt in non-interactive sessions, set the rlib_interactive option to TRUE:
options(rlib_interactive = TRUE)
```
* Opted instead for an initial implementation of `rstudioapi` > `askpass`, but this may be too layered - open to any feedback!
* Also considered [getPass](https://github.com/wrathematics/getPass) but it seems less mature / robust.

Note: leaving [this instance of readline()](https://github.com/r-lib/httr2/blob/10f3d878da94f2597c02c29846d446f3fbd635c8/R/oauth-flow-device.R#L76) since it's not really used to solicit a character string from the user and is likely better handled by another prompt function, anyway.