### PR TITLE
minor performance improvements to url_parse (#429)

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -1,7 +1,7 @@
 parse_media <- function(x) {
   # https://datatracker.ietf.org/doc/html/rfc2616#section-3.7
   pieces <- parse_delim(x, ";")
-  params <- parse_name_equals_value(pieces[-1])
+  params <- parse_name_equals_value(pieces[-1], ";")
 
   if (is_empty(pieces)) {
     list(type = NA_character_)
@@ -15,7 +15,7 @@ parse_www_authenticate <- function(x) {
   # https://stackoverflow.com/questions/10239970
 
   pieces <- parse_in_half(x, " ")
-  params <- parse_name_equals_value(parse_delim(pieces[[2]], ","))
+  params <- parse_name_equals_value(parse_delim(pieces[[2]], ","), ";")
 
   c(list(scheme = pieces[[1]]), params)
 }
@@ -27,7 +27,7 @@ parse_link <- function(x) {
     pieces <- parse_delim(x, ";")
 
     url <- gsub("^<|>$", "", pieces[[1]])
-    params <- parse_name_equals_value(pieces[-1])
+    params <- parse_name_equals_value(pieces[-1], ";")
     c(list(url = url), params)
   }
 
@@ -51,9 +51,14 @@ parse_delim <- function(x, delim, quote = "\"", ...) {
   )
 }
 
-parse_name_equals_value <- function(x) {
-  if (length(x) == 0) return(NULL)
-  pieces <- strsplit(x, "=")
+parse_name_equals_value <- function(x, safe = "&", quote = "\"") {
+  if (length(x) == 0) {
+    return(NULL)
+  }
+  # Note: quotes are removed in the parse_delim function
+  # re-introduce quotes to create a safe pattern to split on
+  safe_pattern <- paste0(quote, safe, quote)
+  pieces <- strsplit(sub("=", safe_pattern, x, fixed = T), safe_pattern, fixed = TRUE)
   pieces_matrix <- do.call(rbind, pieces)
 
   if (ncol(pieces_matrix) == 1) {
@@ -61,9 +66,9 @@ parse_name_equals_value <- function(x) {
   }
 
   # If only one piece, assume it's a field name with empty value
-  found <- pieces_matrix[,1] == pieces_matrix[,2]
+  found <- pieces_matrix[, 1] == pieces_matrix[, 2]
   pieces_matrix[found, 2] <- ""
-  set_names(as.list(pieces_matrix[,2]), pieces_matrix[,1])
+  set_names(as.list(pieces_matrix[, 2]), pieces_matrix[, 1])
 }
 
 parse_in_half <- function(x, pattern) {
@@ -79,6 +84,7 @@ parse_match <- function(x, pattern) {
   m <- regexec(pattern, x, perl = TRUE)
   pieces <- regmatches(x, m)[[1]][-1]
 
+  pieces <- as.list(pieces)
   # replace empty element with null
   pieces[pieces == ""] <- list(NULL)
   return(pieces)
@@ -87,4 +93,3 @@ parse_match <- function(x, pattern) {
 empty_to_null <- function(x) {
   if (x == "") NULL else x
 }
-

--- a/R/parse.R
+++ b/R/parse.R
@@ -84,9 +84,10 @@ parse_match <- function(x, pattern) {
   m <- regexec(pattern, x, perl = TRUE)
   pieces <- regmatches(x, m)[[1]][-1]
 
+  empty <- pieces == ""
   pieces <- as.list(pieces)
   # replace empty element with null
-  pieces[pieces == ""] <- list(NULL)
+  pieces[empty] <- list(NULL)
   return(pieces)
 }
 

--- a/R/url.R
+++ b/R/url.R
@@ -154,7 +154,7 @@ url_build <- function(url) {
 
 query_parse <- function(x) {
   x <- gsub("^\\?", "", x) # strip leading ?, if present
-  params <- parse_name_equals_value(parse_delim(x, "&"))
+  params <- parse_name_equals_value(parse_delim(x, "&"), "&")
 
   if (length(params) == 0) {
     return(NULL)

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -62,3 +62,18 @@ test_that("parse_name_equals_value handles empty values", {
   expect_equal(parse_name_equals_value("a"), list(a = ""))
 })
 
+test_that("parse_name_equals_value multiple params", {
+  expect <- list(
+    list(foo = "=", var1 = "12ab,var2=;var3=,", var4 = "&var5=;out"),
+    list(foo = "=&var1=12ab,var2=", var3 = ",&var4=&var5=", out = ""),
+    list(foo = "=&var1=12ab", var2 = ";var3=", "&var4" = "&var5=;out")
+  )
+  safe <- c("&", ";", ",")
+  params <- "foo==&var1=12ab,var2=;var3=,&var4=\"&\"var5=;out"
+
+  for (i in seq_along(safe)) {
+    pieces <- parse_delim(params, safe[[i]])
+    actual <- parse_name_equals_value(pieces, safe[[i]])
+    expect_equal(actual, expect[[i]])
+  }
+})

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -64,6 +64,21 @@ test_that("empty queries become NULL", {
   expect_equal(query_parse(""), NULL)
 })
 
+test_that("multiple equals in the string", {
+  query <- c(
+    "i=main&mode=front&sid=12ab&enc=+Hello",
+    "var1=&var2=&var3=",
+    "foo==&bar=="
+  )
+  expect_equal(
+    lapply(query, query_parse), list(
+      list(i = "main", mode = "front", sid = "12ab", enc= "+Hello"),
+      list(var1 = "", var2 = "", var3 = ""),
+      list(foo = "=", bar = "=")
+    )
+  )
+})
+
 test_that("validates inputs", {
   expect_snapshot(error = TRUE, {
     query_build(1:3)


### PR DESCRIPTION
This is a minor performance enhancement to function `url_parse`

Issue: https://github.com/r-lib/httr2/issues/429


``` r
url <- 'https://someurl.com/with/query_string?i=main&mode=front&sid=12ab&enc=+Hello'

(bm <- bench::mark(
  httr = httr::parse_url(url),
  httr2 = httr2::url_parse(url),
  new_mthd = url_parse(url), # new method in PR
  urltools = urltools::url_parse(url),
  adaR = adaR::ada_url_parse(url),
  check = F
))
#> # A tibble: 5 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 httr          239µs    256µs     3774.  387.71KB     35.5
#> 2 httr2         207µs    232µs     4100.  466.62KB     34.8
#> 3 new_mthd      129µs    144µs     6509.     4.5MB     39.2
#> 4 urltools      126µs    134µs     7024.    7.45MB     43.8
#> 5 adaR          189µs    202µs     4755.    1.06MB     47.1

bm |> ggplot2::autoplot()
#> Loading required namespace: tidyr
```

![](https://i.imgur.com/kCjxbgG.png)<!-- -->

``` r

urls <- list(
  "/",
  "//google.com",
  "file:///",
  "http://google.com/",
  "http://google.com/path",
  "http://google.com/path?a=1&b=2",
  "http://google.com:80/path?a=1&b=2",
  "http://google.com:80/path?a=1&b=2#frag",
  "http://google.com:80/path?a=1&b=2&c=%7B1%7B2%7D3%7D#frag",
  "http://user@google.com:80/path?a=1&b=2",
  "http://user:pass@google.com:80/path?a=1&b=2",
  "svn+ssh://my.svn.server/repo/trunk",
  'https://someurl.com/with/query_string?i=main&mode=front&sid=12ab&enc=+Hello',
  "http://user:pass@example.com:80/path?a=1&b=2&c={1{2}3}#frag"
)

(bm <- bench::mark(
  httr = lapply(urls, httr::parse_url),
  httr2 = lapply(urls, httr2::url_parse),
  adaR = lapply(urls, adaR::ada_url_parse),
  urltools = lapply(urls, urltools::url_parse),
  new_mthd = lapply(urls, url_parse), # new method in PR
  check = F,
  iterations = 1000
))
#> # A tibble: 5 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 httr          2.5ms   2.55ms      388.   161.9KB     18.3
#> 2 httr2        2.25ms   2.31ms      430.    70.9KB     20.7
#> 3 adaR         2.68ms   2.78ms      358.    34.9KB     24.5
#> 4 urltools     1.73ms    1.8ms      551.    34.9KB     23.5
#> 5 new_mthd     1.59ms   1.66ms      595.    62.9KB     22.2
bm |> ggplot2::autoplot()
```

![](https://i.imgur.com/MmKgKXT.png)<!-- -->

<sup>Created on 2024-01-25 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>