### PR TITLE
Docs fix

### DIFF
--- a/R/req-perform.R
+++ b/R/req-perform.R
@@ -30,8 +30,8 @@
 #' `options(httr2_progress = FALSE)`.
 #'
 #' @param req A [request].
-#' @param path Optionally, path to save body of request. This is useful for
-#'   large responses since it avoids storing the response in memory.
+#' @param path Optionally, path to save body of the response. This is useful 
+#'   for large responses since it avoids storing the response in memory.
 #' @param mock A mocking function. If supplied, this function is called
 #'   with the request. It should return either `NULL` (if it doesn't want to
 #'   handle the request) or a [response] (if it does). See [with_mock()]/

--- a/man/req_perform.Rd
+++ b/man/req_perform.Rd
@@ -15,8 +15,8 @@ req_perform(
 \arguments{
 \item{req}{A \link{request}.}
 
-\item{path}{Optionally, path to save body of request. This is useful for
-large responses since it avoids storing the response in memory.}
+\item{path}{Optionally, path to save body of the response. This is useful
+for large responses since it avoids storing the response in memory.}
 
 \item{verbosity}{How much information to print? This is a wrapper
 around \code{req_verbose()} that uses an integer to control verbosity:


### PR DESCRIPTION
I think this is correct. It's the response body that is being saved, not the request body.