### PR TITLE
Don't let corrupt cache files get in our way

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* Corrupt `rds` files no longer cause the request to fail.
+
 # httr2 1.0.1
 
 * `req_perform_stream()` gains a `round = c("byte", "line")` argument to control 

--- a/R/req-cache.R
+++ b/R/req-cache.R
@@ -89,10 +89,23 @@ cache_debug <- function(req) {
 
 cache_exists <- function(req) {
   if (!req_policy_exists(req, "cache_path")) {
-    FALSE
-  } else {
-    file.exists(req_cache_path(req))
+    return(FALSE)
   }
+  
+  path <- req_cache_path(req)
+  if (!file.exists(path)) {
+    return(FALSE)
+  }
+
+  tryCatch(
+    {
+      readRDS(path)
+      TRUE
+    },
+    error = function(e) {
+      FALSE
+    }
+  )
 }
 
 # Callers responsibility to check that cache exists

--- a/tests/testthat/test-req-cache.R
+++ b/tests/testthat/test-req-cache.R
@@ -160,6 +160,16 @@ test_that("handles responses with files", {
   expect_equal(body, new_path(path2))
 })
 
+test_that("corrupt files are ignored", {
+  cache_dir <- withr::local_tempdir()
+  req <- request("http://example.com") %>% req_cache(cache_dir)
+
+  writeLines(letters, req_cache_path(req))
+  expect_false(cache_exists(req))
+
+  saveRDS(1:10, req_cache_path(req))
+  expect_true(cache_exists(req))
+})
 
 # pruning -----------------------------------------------------------------
 


### PR DESCRIPTION
I'm not sure why this is happening, but this will treat them simple as not cached. Fixes r-lib/pkgdown#2696.