### PR TITLE
Handle 0-byte downloads in `req_perform_parallel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_perform_parallel()` now works when downloading 0 byte files (#478)
 * Corrupt `rds` files no longer cause the request to fail.
 
 # httr2 1.0.1

--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -191,7 +191,15 @@ Performance <- R6Class("Performance", public = list(
   succeed = function(res) {
     self$progress$update()
 
-    body <- if (is.null(self$path)) res$content else new_path(self$path)
+    if (is.null(self$path)) {
+      body <- res$content
+    } else {
+      # Only needed with curl::multi_run()
+      if (!file.exists(self$path)) {
+        file.create(self$path)
+      }
+      body <- new_path(self$path)
+    }
     resp <- new_response(
       method = req_method_get(self$req),
       url = res$url,

--- a/tests/testthat/test-multi-req.R
+++ b/tests/testthat/test-multi-req.R
@@ -34,6 +34,14 @@ test_that("can download files", {
   expect_gt(file.size(paths[[2]]), 0)
 })
 
+test_that("can download 0 byte file", {
+  reqs <- list(request_test("/bytes/0"))
+  paths <- withr::local_tempfile()
+  resps <- req_perform_parallel(reqs, paths = paths)
+
+  expect_equal(file.size(paths[[1]]), 0)
+})
+
 test_that("immutable objects retrieved from cache", {
   req <- request("http://example.com") %>% req_cache(tempfile())
   resp <- response(200,

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -64,6 +64,13 @@ test_that("repeated transient errors still fail", {
   expect_equal(cnd$n, 3)
 })
 
+test_that("can download 0 byte file", {
+  path <- withr::local_tempfile()
+  resps <- req_perform(request_test("/bytes/0"), path = path)
+
+  expect_equal(file.size(path[[1]]), 0)
+})
+
 test_that("can cache requests with etags", {
   req <- request_test("/etag/:etag", etag = "abc") %>% req_cache(tempfile())
 
@@ -128,4 +135,3 @@ test_that("authorization headers are redacted", {
       req_dry_run()
   })
 })
-


### PR DESCRIPTION
Fixes #478