### PR TITLE
req_perform_parallel respects req_error settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_perform_parallel()` now respects error handling in `req_error()`
 * `req_cache()` now defaults the `debug` argument to the `httr2_cache_debug` option to make it easier to debug caching buried in other people's code (#486).
 * `req_oauth_password()` now only asks for your password once (#498).
 * `req_url_query()` now allows you to opt out of escaping for multi-value parameters (#404).

--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -210,7 +210,7 @@ Performance <- R6Class("Performance", public = list(
     )
     resp <- cache_post_fetch(self$req, resp, path = self$path)
     self$resp <- tryCatch(
-      resp_check_status(resp, error_call = self$error_call),
+      handle_resp(self$req, resp, error_call = self$error_call),
       error = identity
     )
     if (is_error(self$resp)) {

--- a/tests/testthat/_snaps/multi-req.md
+++ b/tests/testthat/_snaps/multi-req.md
@@ -19,6 +19,15 @@
       Error in `req_perform_parallel()`:
       ! Could not resolve host: INVALID
 
+# req_perform_parallel respects http_error() body message
+
+    Code
+      req_perform_parallel(reqs)
+    Condition
+      Error in `req_perform_parallel()`:
+      ! HTTP 404 Not Found.
+      * hello
+
 # multi_req_perform is deprecated
 
     Code

--- a/tests/testthat/test-multi-req.R
+++ b/tests/testthat/test-multi-req.R
@@ -25,7 +25,7 @@ test_that("can perform >128 file uploads in parallel", {
   temp <- withr::local_tempfile(lines = letters)
   req <- request(example_url()) %>% req_body_file(temp)
   reqs <- rep(list(req), 150)
-  
+
   expect_no_error(req_perform_parallel(reqs, on_error = "continue"))
 })
 
@@ -53,7 +53,7 @@ test_that("can download 0 byte file", {
 test_that("objects are cached", {
   temp <- withr::local_tempdir()
   req <- request_test("etag/:etag", etag = "abcd") %>% req_cache(temp)
-  
+
   expect_condition(
     resps1 <- req_perform_parallel(list(req)),
     class = "httr2_cache_save"
@@ -113,6 +113,25 @@ test_that("errors can cancel outstanding requests", {
   out <- req_perform_parallel(reqs, on_error = "return")
   expect_s3_class(out[[1]], "httr2_http_404")
   expect_null(out[[2]])
+})
+
+test_that("req_perform_parallel resspects http_error() error override", {
+  reqs <- list2(
+    request_test("/status/:status", status = 404) |> req_error(is_error = ~FALSE),
+    request_test("/status/:status", status = 500) |> req_error(is_error = ~FALSE)
+  )
+  resps <- req_perform_parallel(reqs)
+
+  expect_equal(resp_status(resps[[1]]), 404)
+  expect_equal(resp_status(resps[[2]]), 500)
+})
+
+
+test_that("req_perform_parallel respects http_error() body message", {
+  reqs <- list2(
+    request_test("/status/:status", status = 404) |> req_error(body = ~"hello")
+  )
+  expect_snapshot(req_perform_parallel(reqs), error = TRUE)
 })
 
 test_that("multi_req_perform is deprecated", {


### PR DESCRIPTION
Discovered while working on #505 - It seems like an oversight that `req_perform_multi()` doesn't respect `req_error()` error handling.