### PR TITLE
jwt encode hmac wrapper typo fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `jwt_encode_hmac()` now calls correct underlying function `jose::jwt_encode_hmac()` and has correct default size parameter value' (@denskh, #508).
 * `req_perform_parallel()` now respects error handling in `req_error()`
 * New function `req_perform_promise()` allows creating a `promises::promise` for a request that runs in the background (#501, @gergness).
 

--- a/R/jwt.R
+++ b/R/jwt.R
@@ -65,7 +65,7 @@ jwt_encode_sig <- function(claim, key, size = 256, header = list()) {
 #' @export
 #' @rdname jwt_claim
 #' @param secret String or raw vector with a secret passphrase.
-jwt_encode_hmac <- function(claim, secret, size = size, header = list()) {
+jwt_encode_hmac <- function(claim, secret, size = 256, header = list()) {
   check_installed("jose")
-  jose::jwt_encode_sig(claim, secret, size = size, header = header)
+  jose::jwt_encode_hmac(claim, secret, size = size, header = header)
 }

--- a/man/jwt_claim.Rd
+++ b/man/jwt_claim.Rd
@@ -19,7 +19,7 @@ jwt_claim(
 
 jwt_encode_sig(claim, key, size = 256, header = list())
 
-jwt_encode_hmac(claim, secret, size = size, header = list())
+jwt_encode_hmac(claim, secret, size = 256, header = list())
 }
 \arguments{
 \item{iss}{Issuer claim. Identifies the principal that issued the JWT.}


### PR DESCRIPTION
Fixes httr2::jwt_encode_hmac  wrapper parameters and calls correct jose::jwt_encode_hmac function. Issue: r-lib/httr2#508.