### PR TITLE
Allow `req_perform_stream()` to perform non-blocking reads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* `req_perform_stream()` can now stream data as it arrives rather than
+   waiting for the buffer to fill (#519).
+
 # httr2 1.0.3
 
 * `jwt_encode_hmac()` now calls correct underlying function

--- a/R/req-perform-stream.R
+++ b/R/req-perform-stream.R
@@ -87,7 +87,7 @@ req_perform_stream <- function(req,
     } else {
       stop <- Sys.time() + wait_for
       repeat({
-        buf <- c(buf, readBin(stream, raw(), buffer_kb))
+        buf <- c(buf, readBin(stream, raw(), (buffer_kb * 1024) - length(buf)))
         if (length(buf) > buffer_kb * 1024) {
           break
         }

--- a/R/req-perform-stream.R
+++ b/R/req-perform-stream.R
@@ -42,7 +42,7 @@ req_perform_stream <- function(req,
                                timeout_sec = Inf,
                                buffer_kb = 64,
                                wait_for = Inf,
-                               round = c("byte", "line")) {
+                               round = c("byte", "line", "sse")) {
   check_request(req)
 
   handle <- req_handle(req)
@@ -117,7 +117,7 @@ req_perform_stream <- function(req,
   resp
 }
 
-as_round_function <- function(round = c("byte", "line"),
+as_round_function <- function(round = c("byte", "line", "sse"),
                               error_call = caller_env()) {
   if (is.function(round)) {
     check_function2(round, args = "bytes")

--- a/man/req_perform_stream.Rd
+++ b/man/req_perform_stream.Rd
@@ -27,13 +27,14 @@ worth of data to process. It must return \code{TRUE} to continue streaming.}
 
 \item{wait_for}{Number of seconds to wait for more data before calling
 \code{callback}. If this is \code{Inf} (the default), \code{callback} will be called
-whenever there is the buffer is full. If this is \code{0}, \code{callback} will be
-called whenever there is any data.}
+whenever the buffer is full. If this is \code{0}, \code{callback} will be
+called whenever there is any data. For other values, \code{callback} will be
+called whenever the buffer is full or \code{wait_for} seconds have passed.}
 
 \item{round}{How should the raw vector sent to \code{callback} be rounded?
-Choose \code{"byte"}, \code{"line"}, or supply your own function that takes a
-raw vector of \code{bytes} and returns the locations of possible cut points
-(or \code{integer()} if there are none).}
+Choose \code{"byte"}, \code{"line"}, \code{"sse"} (for server-sent events) or supply
+your own function that takes a raw vector of \code{bytes} and returns the
+locations of possible cut points (or \code{integer()} if there are none).}
 }
 \value{
 An HTTP \link{response}. The body will be empty if the request was

--- a/man/req_perform_stream.Rd
+++ b/man/req_perform_stream.Rd
@@ -11,7 +11,7 @@ req_perform_stream(
   timeout_sec = Inf,
   buffer_kb = 64,
   wait_for = Inf,
-  round = c("byte", "line")
+  round = c("byte", "line", "sse")
 )
 }
 \arguments{

--- a/man/req_perform_stream.Rd
+++ b/man/req_perform_stream.Rd
@@ -10,6 +10,7 @@ req_perform_stream(
   callback,
   timeout_sec = Inf,
   buffer_kb = 64,
+  wait_for = Inf,
   round = c("byte", "line")
 )
 }
@@ -23,6 +24,11 @@ worth of data to process. It must return \code{TRUE} to continue streaming.}
 \item{timeout_sec}{Number of seconds to process stream for.}
 
 \item{buffer_kb}{Buffer size, in kilobytes.}
+
+\item{wait_for}{Number of seconds to wait for more data before calling
+\code{callback}. If this is \code{Inf} (the default), \code{callback} will be called
+whenever there is the buffer is full. If this is \code{0}, \code{callback} will be
+called whenever there is any data.}
 
 \item{round}{How should the raw vector sent to \code{callback} be rounded?
 Choose \code{"byte"}, \code{"line"}, or supply your own function that takes a

--- a/tests/testthat/_snaps/req-perform-stream.md
+++ b/tests/testthat/_snaps/req-perform-stream.md
@@ -41,7 +41,7 @@
       as_round_function("bytes")
     Condition
       Error:
-      ! `round` must be one of "byte" or "line", not "bytes".
+      ! `round` must be one of "byte", "line", or "sse", not "bytes".
       i Did you mean "byte"?
     Code
       as_round_function(function(x) 1)

--- a/tests/testthat/test-req-perform-stream.R
+++ b/tests/testthat/test-req-perform-stream.R
@@ -66,10 +66,15 @@ test_that("can stream data as it arrives", {
     TRUE
   }
 
-  resp <- request_test("/stream-bytes/1024?chunk-size=64") |>
+  resp <- request_test("/stream-bytes/102400") |>
+    req_url_query(chunk_size = 1024) |>
     req_perform_stream(accumulate_bytes, wait_for = 0)
-  expect_equal(sum(bytes), 1024)
-  expect_equal(length(bytes), 1024 / 64)
+  expect_equal(sum(bytes), 102400)
+  # I'm not sure why this is so much smaller than 100, but I suspect it
+  # because the endpoint is pouring out bytes as fast as it can, and since
+  # the code in the callback takes a non-trivial amount of time, more data
+  # ends up in the curl buffer
+  expect_gte(length(bytes), 5)
 })
 
 test_that("can accumulate bytes up to a certain time", {

--- a/tests/testthat/test-req-perform-stream.R
+++ b/tests/testthat/test-req-perform-stream.R
@@ -66,8 +66,8 @@ test_that("can stream data as it arrives", {
     TRUE
   }
 
-  resp <- request_test("/stream-bytes/102400") |>
-    req_url_query(chunk_size = 1024) |>
+  resp <- request_test("/stream-bytes/102400") %>%
+    req_url_query(chunk_size = 1024) %>%
     req_perform_stream(accumulate_bytes, wait_for = 0)
   expect_equal(sum(bytes), 102400)
   # I'm not sure why this is so much smaller than 100, but I suspect it
@@ -84,8 +84,8 @@ test_that("can accumulate bytes up to a certain time", {
     TRUE
   }
 
-  resp <- request_test("/drip") |>
-    req_url_query(duration = 1, numbytes = 2) |>
+  resp <- request_test("/drip") %>%
+    req_url_query(duration = 1, numbytes = 2) %>%
     req_perform_stream(accumulate_bytes, wait_for = 0.5)
   expect_equal(bytes, c(1, 1))
 })


### PR DESCRIPTION
The default behaviour stays the same, but you can now specify `wait_for` in order to switch to a non-blocking request and call the callback as the data arrives.

Fixes #519


@jcheng5 Does that feel like the right argument name? I have kept the behaviour the same as previously, but maybe the default should be `wait_for = 0`? Does the `wait_for` implementation loop look ok to you?