### PR TITLE
Ensure `resp_body_html()` and `resp_body_xml()` work with saved path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `resp_body_html()` and `resp_body_xml()` now work when `req_perform()` is given a path (#448).
 * `req_body_file()` now works with files >64kb once more (#524).
 * New `req_perform_connection()` for working with streaming data. Unlike `req_perform_stream()` which uses callbacks, `req_perform_connection()` returns a regular response object with a connection as the body. It's paired with `resp_stream_bytes()`, `resp_stream_lines()`, and `resp_stream_sse()` that allows you to stream chunks as you want them. Unlike `req_perform_stream()` it supports `req_retry()` (with @jcheng5, #519).
 

--- a/R/resp-body.R
+++ b/R/resp-body.R
@@ -125,7 +125,8 @@ resp_body_html <- function(resp, check_type = TRUE, ...) {
     check_type = check_type
   )
 
-  xml2::read_html(resp$body, ...)
+  body <- resp_body_raw(resp)
+  xml2::read_html(body, ...)
 }
 
 #' @rdname resp_body_raw
@@ -146,7 +147,8 @@ resp_body_xml <- function(resp, check_type = TRUE, ...) {
     check_type = check_type
   )
 
-  resp$cache[[key]] <- xml2::read_xml(resp$body, ...)
+  body <- resp_body_raw(resp)
+  resp$cache[[key]] <- xml2::read_xml(body, ...)
   resp$cache[[key]]
 }
 

--- a/tests/testthat/test-resp-body.R
+++ b/tests/testthat/test-resp-body.R
@@ -30,6 +30,19 @@ test_that("can retrieve parsed body", {
   expect_s3_class(resp_body_xml(resp), "xml_document")
 })
 
+test_that("can retrieve parsed body when saved to a file", {
+  path <- withr::local_tempfile()
+  resp <- request_test("/json") %>% req_perform(path)
+  expect_type(resp_body_json(resp), "list")
+
+  resp <- request_test("/html") %>% req_perform(path)
+  expect_s3_class(resp_body_html(resp), "xml_document")
+
+  resp <- request_test("/xml") %>% req_perform(path)
+  expect_s3_class(resp_body_xml(resp), "xml_document")
+})
+
+
 test_that("resp_body_json stores parsed result", {
   resp <- request_test("/json") %>% req_perform()
   json1 <- resp_body_json(resp)

--- a/tests/testthat/test-resp-body.R
+++ b/tests/testthat/test-resp-body.R
@@ -42,7 +42,6 @@ test_that("can retrieve parsed body when saved to a file", {
   expect_s3_class(resp_body_xml(resp), "xml_document")
 })
 
-
 test_that("resp_body_json stores parsed result", {
   resp <- request_test("/json") %>% req_perform()
   json1 <- resp_body_json(resp)


### PR DESCRIPTION
Fixes #448