### PR TITLE
Add a done callback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_body_file()` no longer leaks a connection if the response doesn't complete succesfully (#534).
 * `req_cache()` now re-caches the response if the body is hasn't been modified but the headers have changed (#442).
 * `req_cache()` works better when `req_perform()` sets a path (#442).
 * `req_body_*()` now give informative error if you attempt to change the body type (#451).

--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -168,7 +168,7 @@ Performance <- R6Class("Performance", public = list(
       self$resp <- req
     } else {
       self$req_prep <- req_prepare(req)
-      self$handle <- req_handle(self$req)
+      self$handle <- req_handle(req)
       curl::handle_setopt(self$handle, url = req$url)
     }
   },

--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -192,7 +192,7 @@ Performance <- R6Class("Performance", public = list(
 
   succeed = function(res) {
     self$progress$update()
-    req_done(self$req_prep)
+    req_completed(self$req_prep)
 
     if (is.null(self$path)) {
       body <- res$content
@@ -223,7 +223,7 @@ Performance <- R6Class("Performance", public = list(
 
   fail = function(msg) {
     self$progress$update()
-    req_done(self$req_prep)
+    req_completed(self$req_prep)
 
     self$resp <- error_cnd(
       "httr2_failure",

--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -147,6 +147,7 @@ pool_run <- function(pool, perfs, on_error = "continue") {
 # Wrap up all components of request -> response in a single object
 Performance <- R6Class("Performance", public = list(
   req = NULL,
+  req_prep = NULL,
   path = NULL,
 
   handle = NULL,
@@ -166,7 +167,8 @@ Performance <- R6Class("Performance", public = list(
     if (is_response(req)) {
       self$resp <- req
     } else {
-      self$handle <- req_handle(req)
+      self$req_prep <- req_prepare(req)
+      self$handle <- req_handle(self$req)
       curl::handle_setopt(self$handle, url = req$url)
     }
   },
@@ -190,6 +192,7 @@ Performance <- R6Class("Performance", public = list(
 
   succeed = function(res) {
     self$progress$update()
+    req_done(self$req_prep)
 
     if (is.null(self$path)) {
       body <- res$content
@@ -220,6 +223,7 @@ Performance <- R6Class("Performance", public = list(
 
   fail = function(msg) {
     self$progress$update()
+    req_done(self$req_prep)
 
     self$resp <- error_cnd(
       "httr2_failure",

--- a/R/req-body.R
+++ b/R/req-body.R
@@ -232,18 +232,14 @@ req_body_apply <- function(req) {
     # Only open connection if needed
     delayedAssign("con", file(data, "rb"))
 
-    readfunction <- function(nbytes, ...) {
-      readBin(con, "raw", nbytes)
-    }
-    seekfunction <- function(offset, ...) {
-      seek(con, where = offset)
-    }
-
-    req <- req_policies(req, done = function() close(con))
+    req <- req_policies(
+      req,
+      done = function() close(con)
+    )
     req <- req_options(req,
       post = TRUE,
-      readfunction = readfunction,
-      seekfunction = seekfunction,
+      readfunction = function(nbytes, ...) readBin(con, "raw", nbytes),
+      seekfunction = function(offset, ...) seek(con, where = offset),
       postfieldsize_large = size
     )
   } else if (type == "raw") {
@@ -283,8 +279,4 @@ req_body_apply_raw <- function(req, body) {
     postfieldsize = length(body),
     postfields = body
   )
-}
-
-req_done <- function(req) {
-  req_policy_call(req, "done", list(), NULL)
 }

--- a/R/req-perform-stream.R
+++ b/R/req-perform-stream.R
@@ -147,7 +147,7 @@ req_perform_connection <- function(req,
     }
   }
 
-  req_done(req_prep)
+  req_completed(req_prep)
 
   if (error_is_error(req, resp)) {
     # Read full body if there's an error

--- a/R/req-perform-stream.R
+++ b/R/req-perform-stream.R
@@ -39,7 +39,6 @@ req_perform_stream <- function(req,
                                round = c("byte", "line")) {
   check_request(req)
 
-  handle <- req_handle(req)
   check_function(callback)
   check_number_decimal(timeout_sec, min = 0)
   check_number_decimal(buffer_kb, min = 0)
@@ -123,7 +122,8 @@ req_perform_connection <- function(req,
   mode <- arg_match(mode)
   con_mode <- if (mode == "text") "rf" else "rbf"
 
-  handle <- req_handle(req)
+  req_prep <- req_prepare(req)
+  handle <- req_handle(req_prep)
   the$last_request <- req
 
   tries <- 0
@@ -146,6 +146,8 @@ req_perform_connection <- function(req,
       break
     }
   }
+
+  req_done(req_prep)
 
   if (error_is_error(req, resp)) {
     # Read full body if there's an error

--- a/R/req-perform.R
+++ b/R/req-perform.R
@@ -123,7 +123,7 @@ req_perform <- function(
         )
       }
     )
-    req_done(req_prep)
+    req_completed(req_prep)
 
     if (is_error(resp)) {
       tries <- tries + 1
@@ -273,6 +273,8 @@ req_dry_run <- function(req, quiet = FALSE, redact_headers = TRUE) {
   ))
 }
 
+# Must call req_prepare(), then req_handle(), then after the request has been
+# performed, req_completed()
 req_prepare <- function(req) {
   req <- req_method_apply(req)
   req <- req_body_apply(req)
@@ -292,6 +294,9 @@ req_handle <- function(req) {
   }
 
   handle
+}
+req_completed <- function(req) {
+  req_policy_call(req, "done", list(), NULL)
 }
 
 new_path <- function(x) structure(x, class = "httr2_path")

--- a/R/req-perform.R
+++ b/R/req-perform.R
@@ -94,7 +94,8 @@ req_perform <- function(
     return(req)
   }
 
-  handle <- req_handle(req)
+  req_prep <- req_prepare(req)
+  handle <- req_handle(req_prep)
   max_tries <- retry_max_tries(req)
   deadline <- Sys.time() + retry_max_seconds(req)
 
@@ -122,6 +123,7 @@ req_perform <- function(
         )
       }
     )
+    req_done(req_prep)
 
     if (is_error(resp)) {
       tries <- tries + 1
@@ -129,7 +131,8 @@ req_perform <- function(
     } else if (!reauth && resp_is_invalid_oauth_token(req, resp)) {
       reauth <- TRUE
       req <- auth_oauth_sign(req, TRUE)
-      handle <- req_handle(req)
+      req_prep <- req_prepare(req)
+      handle <- req_handle(req_prep)
       delay <- 0
     } else if (retry_is_transient(req, resp)) {
       tries <- tries + 1
@@ -258,6 +261,7 @@ req_dry_run <- function(req, quiet = FALSE, redact_headers = TRUE) {
     req <- req_options(req, debugfunction = debug, verbose = TRUE)
   }
 
+  req <- req_prepare(req)
   handle <- req_handle(req)
   curl::handle_setopt(handle, url = req$url)
   resp <- curl::curl_echo(handle, progress = FALSE)
@@ -269,7 +273,7 @@ req_dry_run <- function(req, quiet = FALSE, redact_headers = TRUE) {
   ))
 }
 
-req_handle <- function(req) {
+req_prepare <- function(req) {
   req <- req_method_apply(req)
   req <- req_body_apply(req)
 
@@ -277,6 +281,9 @@ req_handle <- function(req) {
     req <- req_user_agent(req)
   }
 
+  req
+}
+req_handle <- function(req) {
   handle <- curl::new_handle()
   curl::handle_setheaders(handle, .list = headers_flatten(req$headers))
   curl::handle_setopt(handle, .list = req$options)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,3 @@
+testthat::set_state_inspector(function() {
+  getAllConnections()
+})


### PR DESCRIPTION
So we can ensure that open connections are always closed. Fixes #534.