### PR TITLE
By default, don't retry on curl failures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_retry()` no longer treates low-level HTTP failures the same way as transient errors by default. You can return to the previous behaviour with `retry_on_error = TRUE`.
 * `req_perform_iterative()` is no longer experimental.
 * New `req_cookie_set()` allows you to set client side cookies (#369).
 * `req_body_file()` no longer leaks a connection if the response doesn't complete succesfully (#534).

--- a/R/resp-headers.R
+++ b/R/resp-headers.R
@@ -134,6 +134,8 @@ resp_encoding <- function(resp) {
 #' resp <- response(headers = "Retry-After: Mon, 20 Sep 2025 21:44:05 UTC")
 #' resp |> resp_retry_after()
 resp_retry_after <- function(resp) {
+  check_response(resp)
+
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
   val <- resp_header(resp, "Retry-After")
   if (is.null(val)) {

--- a/man/req_retry.Rd
+++ b/man/req_retry.Rd
@@ -8,6 +8,7 @@ req_retry(
   req,
   max_tries = NULL,
   max_seconds = NULL,
+  retry_on_failure = FALSE,
   is_transient = NULL,
   backoff = NULL,
   after = NULL
@@ -23,6 +24,9 @@ will not retry.
 
 \code{max_tries} is the total number of attempts make, so this should always
 be greater than one.`}
+
+\item{retry_on_failure}{Treat low-level failures as if they are
+transient errors, and can be retried.}
 
 \item{is_transient}{A predicate function that takes a single argument
 (the response) and returns \code{TRUE} or \code{FALSE} specifying whether or not
@@ -43,17 +47,17 @@ A modified HTTP \link{request}.
 \code{req_retry()} alters \code{\link[=req_perform]{req_perform()}} so that it will automatically retry
 in the case of failure. To activate it, you must specify either the total
 number of requests to make with \code{max_tries} or the total amount of time
-to spend with \code{max_seconds}. Then \code{req_perform()} will retry if:
-\itemize{
-\item Either the HTTP request or HTTP response doesn't complete successfully
+to spend with \code{max_seconds}. Then \code{req_perform()} will retry if the error is
+"transient", i.e. it's an HTTP error that can be resolved by waiting. By
+default, 429 and 503 statuses are treated as transient, but if the API you
+are wrapping has other transient status codes (or conveys transient-ness
+with some other property of the response), you can override the default
+with \code{is_transient}.
+
+Additionally, if you set \code{retry_on_failure = TRUE}, the request will retry
+if either the HTTP request or HTTP response doesn't complete successfully
 leading to an error from curl, the lower-level library that httr2 uses to
 perform HTTP request. This occurs, for example, if your wifi is down.
-\item The error is "transient", i.e. it's an HTTP error that can be resolved
-by waiting. By default, 429 and 503 statuses are treated as transient,
-but if the API you are wrapping has other transient status codes (or
-conveys transient-ness with some other property of the response), you can
-override the default with \code{is_transient}.
-}
 
 It's a bad idea to immediately retry a request, so \code{req_perform()} will
 wait a little before trying again:

--- a/tests/testthat/_snaps/req-retries.md
+++ b/tests/testthat/_snaps/req-retries.md
@@ -19,8 +19,8 @@
       Error in `req_retry()`:
       ! `max_seconds` must be a whole number or `NULL`, not the string "x".
     Code
-      req_retry(req, retry_on_error = "x")
+      req_retry(req, retry_on_failure = "x")
     Condition
       Error in `req_retry()`:
-      ! `retry_on_error` must be `TRUE` or `FALSE`, not the string "x".
+      ! `retry_on_failure` must be `TRUE` or `FALSE`, not the string "x".
 

--- a/tests/testthat/_snaps/req-retries.md
+++ b/tests/testthat/_snaps/req-retries.md
@@ -18,4 +18,9 @@
     Condition
       Error in `req_retry()`:
       ! `max_seconds` must be a whole number or `NULL`, not the string "x".
+    Code
+      req_retry(req, retry_on_error = "x")
+    Condition
+      Error in `req_retry()`:
+      ! `retry_on_error` must be `TRUE` or `FALSE`, not the string "x".
 

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -54,6 +54,16 @@ test_that("persistent HTTP errors only get single attempt", {
   expect_equal(cnd$n, 1)
 })
 
+test_that("don't retry curl errors by default", {
+  req <- request("frooble") %>% req_retry(max_tries = 2)
+  expect_error(req_perform(req), class = "httr2_failure")
+
+  # But can opt-in to it
+  req <- request("frooble") %>% req_retry(max_tries = 2, retry_on_error = TRUE)
+  cnd <- catch_cnd(req_perform(req), "httr2_retry")
+  expect_equal(cnd$tries, 1)
+})
+
 test_that("can retry a transient error", {
   req <- local_app_request(function(req, res) {
     i <- res$app$locals$i %||% 1

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -55,11 +55,11 @@ test_that("persistent HTTP errors only get single attempt", {
 })
 
 test_that("don't retry curl errors by default", {
-  req <- request("frooble") %>% req_retry(max_tries = 2)
+  req <- request("") %>% req_retry(max_tries = 2)
   expect_error(req_perform(req), class = "httr2_failure")
 
   # But can opt-in to it
-  req <- request("frooble") %>% req_retry(max_tries = 2, retry_on_failure = TRUE)
+  req <- request("") %>% req_retry(max_tries = 2, retry_on_failure = TRUE)
   cnd <- catch_cnd(req_perform(req), "httr2_retry")
   expect_equal(cnd$tries, 1)
 })
@@ -173,7 +173,7 @@ test_that("can retrieve last request and response", {
 })
 
 test_that("can last response is NULL if it fails", {
-  req <- request("frooble") %>% req_timeout(0.1)
+  req <- request("")
   try(req_perform(req), silent = TRUE)
 
   expect_equal(last_request(), req)

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -59,7 +59,7 @@ test_that("don't retry curl errors by default", {
   expect_error(req_perform(req), class = "httr2_failure")
 
   # But can opt-in to it
-  req <- request("frooble") %>% req_retry(max_tries = 2, retry_on_error = TRUE)
+  req <- request("frooble") %>% req_retry(max_tries = 2, retry_on_failure = TRUE)
   cnd <- catch_cnd(req_perform(req), "httr2_retry")
   expect_equal(cnd$tries, 1)
 })

--- a/tests/testthat/test-req-retries.R
+++ b/tests/testthat/test-req-retries.R
@@ -72,6 +72,7 @@ test_that("validates its inputs", {
   expect_snapshot(error = TRUE, {
     req_retry(req, max_tries = 1)
     req_retry(req, max_seconds = "x")
+    req_retry(req, retry_on_error = "x")
   })
 })
 

--- a/tests/testthat/test-req-retries.R
+++ b/tests/testthat/test-req-retries.R
@@ -72,7 +72,7 @@ test_that("validates its inputs", {
   expect_snapshot(error = TRUE, {
     req_retry(req, max_tries = 1)
     req_retry(req, max_seconds = "x")
-    req_retry(req, retry_on_error = "x")
+    req_retry(req, retry_on_failure = "x")
   })
 })
 


### PR DESCRIPTION
Since they're not usually resolvable just by waiting, and it's better to give a clear error.

@jcheng5 does this make sense to you? I'm not sure what I was thinking at the time, but the previous behaviour treated low-level HTTP errors as transient, which I don't think is usually the case.