### PR TITLE
Use prepared request in Performance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_perform_parallel()` and `req_perform_promise()` now correctly set up the method and body (#549).
+
 # httr2 1.0.4
 
 * `req_body_file()` now works with files >64kb once more (#524) and no longer leaks a connection if the response doesn't complete succesfully (#534).

--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -168,7 +168,7 @@ Performance <- R6Class("Performance", public = list(
       self$resp <- req
     } else {
       self$req_prep <- req_prepare(req)
-      self$handle <- req_handle(req)
+      self$handle <- req_handle(self$req_prep)
       curl::handle_setopt(self$handle, url = req$url)
     }
   },

--- a/tests/testthat/test-multi-req.R
+++ b/tests/testthat/test-multi-req.R
@@ -3,6 +3,11 @@ test_that("request and paths must match", {
   expect_snapshot(req_perform_parallel(req, letters), error = TRUE)
 })
 
+test_that("correctly prepares request", {
+  reqs <- list(request_test("/post") %>% req_method("POST"))
+  expect_no_error(req_perform_parallel(reqs))
+})
+
 test_that("requests happen in parallel", {
   # GHA MacOS builder seems to be very slow
   skip_if(

--- a/tests/testthat/test-req-perform-connection.R
+++ b/tests/testthat/test-req-perform-connection.R
@@ -5,6 +5,11 @@ test_that("validates inputs", {
   })
 })
 
+test_that("correctly prepares request", {
+  req <- request_test("/post") %>% req_method("POST")
+  expect_no_error(resp <- req_perform_connection(req))
+})
+
 test_that("can read all data from a connection", {
   resp <- request_test("/stream-bytes/2048") %>% req_perform_connection()
   withr::defer(close(resp))

--- a/tests/testthat/test-req-promise.R
+++ b/tests/testthat/test-req-promise.R
@@ -36,6 +36,12 @@ test_that("returns a promise that resolves", {
   expect_equal(resp_status(p2_value), 200)
 })
 
+test_that("correctly prepares request", {
+  req <- request_test("/post") %>% req_method("POST")
+  prom <- req_perform_promise(req)
+  expect_no_error(extract_promise(prom))
+})
+
 test_that("can promise to download files", {
   req <- request_test("/json")
   path <- withr::local_tempfile()


### PR DESCRIPTION
This ensures that the method and body are correctly set for `req_perform_parallel()` and `req_perform_promise()`. Fixes #549