### PR TITLE
Update curl version dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     R (>= 4.0)
 Imports:
     cli (>= 3.0.0),
-    curl (>= 5.2.2),
+    curl (>= 6.0.1),
     glue,
     lifecycle,
     magrittr,


### PR DESCRIPTION
Without this, `req_perform_promise` doesn't work correctly, nor does elmer