### PR TITLE
Bump later requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     jose,
     jsonlite,
     knitr,
-    later (>= 1.3.2.9001),
+    later (>= 1.4.0),
     paws.common,
     promises,
     rmarkdown,
@@ -54,4 +54,3 @@ Config/testthat/start-first: resp-stream, req-perform
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Remotes: r-lib/later


### PR DESCRIPTION
Uses the newly-released version of `later`.

I noticed that Joe moved it up to Imports at `elmer` partly as 'suggests' versions aren't enforced.

I haven't done that here, but you may wish to consider.