### PR TITLE
Add missing "should" to roxygen docs

### DIFF
--- a/R/req-auth.R
+++ b/R/req-auth.R
@@ -5,8 +5,8 @@
 #'
 #' @inheritParams req_perform
 #' @param username User name.
-#' @param password Password. You avoid entering the password directly when
-#'   calling this function as it will be captured by `.Rhistory`. Instead,
+#' @param password Password. You should avoid entering the password directly
+#'   when calling this function as it will be captured by `.Rhistory`. Instead,
 #'   leave it unset and the default behaviour will prompt you for it
 #'   interactively.
 #' @returns A modified HTTP [request].

--- a/man/req_auth_basic.Rd
+++ b/man/req_auth_basic.Rd
@@ -11,8 +11,8 @@ req_auth_basic(req, username, password = NULL)
 
 \item{username}{User name.}
 
-\item{password}{Password. You avoid entering the password directly when
-calling this function as it will be captured by \code{.Rhistory}. Instead,
+\item{password}{Password. You should avoid entering the password directly
+when calling this function as it will be captured by \code{.Rhistory}. Instead,
 leave it unset and the default behaviour will prompt you for it
 interactively.}
 }

--- a/man/req_oauth_password.Rd
+++ b/man/req_oauth_password.Rd
@@ -31,8 +31,8 @@ oauth_flow_password(
 
 \item{username}{User name.}
 
-\item{password}{Password. You avoid entering the password directly when
-calling this function as it will be captured by \code{.Rhistory}. Instead,
+\item{password}{Password. You should avoid entering the password directly
+when calling this function as it will be captured by \code{.Rhistory}. Instead,
 leave it unset and the default behaviour will prompt you for it
 interactively.}
 


### PR DESCRIPTION
Thanks so much for this package!  It's a huge lifesaver for a lot of my team's work.

I found what I think was a missing (and important) *"should"* keyword in the documentation for the `req_auth_basic()` function.  When adding this word to the roxygen param, I kept the line width to 80 characters.

Let me know if you'd like me to add another commit that also updates the associated `.Rd` file, or if that is part of the automated build process.