### PR TITLE
pass options from req_perform_iterative to req_perform

### DIFF
--- a/R/iterate.R
+++ b/R/iterate.R
@@ -79,6 +79,7 @@
 #'   a glue string that uses `{i}` to distinguish different requests.
 #'   Useful for large responses because it avoids storing the response in
 #'   memory.
+#' @param ... Further options passed to [req_perform]
 #' @return
 #' A list, at most length `max_reqs`, containing [response]s and possibly one
 #' error object, if `on_error` is `"return"` and one of the requests errors.
@@ -141,7 +142,7 @@ req_perform_iterative <- function(req,
         return = function(cnd) cnd
       )
       resp <- try_fetch(
-        req_perform(req, path = get_path(i)),
+        req_perform(req, path = get_path(i), ...),
         httr2_error = httr2_error
       )
       resps[[i]] <- resp

--- a/man/req_perform_iterative.Rd
+++ b/man/req_perform_iterative.Rd
@@ -10,7 +10,8 @@ req_perform_iterative(
   path = NULL,
   max_reqs = 20,
   on_error = c("stop", "return"),
-  progress = TRUE
+  progress = TRUE,
+  ...
 )
 }
 \arguments{
@@ -38,6 +39,8 @@ far, as well as an error object for the failed request.
 \item{progress}{Display a progress bar? Use \code{TRUE} to turn on a basic
 progress bar, use a string to give it a name, or see \link{progress_bars} to
 customise it in other ways.}
+
+\item{...}{Further options passed to \link{req_perform}}
 }
 \value{
 A list, at most length \code{max_reqs}, containing \link{response}s and possibly one


### PR DESCRIPTION
This allows users to pass the `verbosity`, `mock`, and `error_call` options to `req_perform` when using `req_perform_iterative`