### PR TITLE
[Bug/Docs]: Update roxygen2 @param tag for `after` argument of `req_retry` (#597)

### DIFF
--- a/R/req-retries.R
+++ b/R/req-retries.R
@@ -47,7 +47,7 @@
 #' @param backoff A function that takes a single argument (the number of failed
 #'   attempts so far) and returns the number of seconds to wait.
 #' @param after A function that takes a single argument (the response) and
-#'   returns either a number of seconds to wait or `NULL`, which indicates
+#'   returns either a number of seconds to wait or `NA`, which indicates
 #'   that a precise wait time is not available that the `backoff` strategy
 #'   should be used instead..
 #' @returns A modified HTTP [request].

--- a/man/req_retry.Rd
+++ b/man/req_retry.Rd
@@ -36,7 +36,7 @@ the response represents a transient error.}
 attempts so far) and returns the number of seconds to wait.}
 
 \item{after}{A function that takes a single argument (the response) and
-returns either a number of seconds to wait or \code{NULL}, which indicates
+returns either a number of seconds to wait or \code{NA}, which indicates
 that a precise wait time is not available that the \code{backoff} strategy
 should be used instead..}
 }


### PR DESCRIPTION
This PR corresponds to Issue #597 and simply changed a line of roxygen2 and re-documented.