### PR TITLE
Improve progress bar handling

### DIFF
--- a/R/multi-req.R
+++ b/R/multi-req.R
@@ -75,6 +75,7 @@ req_perform_parallel <- function(reqs,
     perfs[[i]]$submit(pool)
   }
 
+  progress$update(set = 0)
   pool_run(pool, perfs, on_error = on_error)
   progress$done()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -277,10 +277,17 @@ create_progress_bar <- function(total,
 
   id <- exec(cli::cli_progress_bar, !!!args)
 
+  # These functions are called within multi_req_perform() from curl
+  # threads so the original progress may have gone away. If that has
+  # happened we'll just ignore the error.
   list(
-    update = function(...) cli::cli_progress_update(..., id = id),
-    done = function() cli::cli_progress_done(id = id)
+    update = function(...) try_quiet(cli::cli_progress_update(..., id = id)),
+    done = function() try_quiet(cli::cli_progress_done(id = id))
   )
+}
+
+try_quiet <- function(code) {
+  tryCatch(code, error = function(cnd) NULL)
 }
 
 imap <- function(.x, .f, ...) {


### PR DESCRIPTION
When `req_perform_parallel()` is terminated, it seems like it's possible for a curl progress call to complete after the progress bar has been terminated.

Fixes #594