### PR TITLE
Use a stricter definition of header names

### DIFF
--- a/R/req-options.R
+++ b/R/req-options.R
@@ -207,7 +207,7 @@ verbose_header <- function(prefix, x, redact = TRUE, to_redact = NULL) {
   lines <- unlist(strsplit(x, "\r?\n", useBytes = TRUE))
 
   for (line in lines) {
-    if (grepl(":", line, fixed = TRUE)) {
+    if (grepl("^[-a-zA-z0-9]+:", line)) {
       header <- headers_redact(as_headers(line), redact, to_redact = to_redact)
       cli::cat_line(prefix, cli::style_bold(names(header)), ": ", header)
     } else {

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -225,3 +225,8 @@ test_that("authorization headers are redacted", {
       req_dry_run()
   })
 })
+
+test_that("doen't add space to urls (#567)", {
+  req <- request("https://example.com/test:1:2")
+  expect_output(req_dry_run(req), "test:1:2")
+})


### PR DESCRIPTION
To make it less likely that URLs (or other non-header contents) are mangled. This only affects verobse printing (including `req_dry_run()`) so it shouldn't cause problems even if it's not 100% accurate.

Fixes #567