### PR TITLE
Make parallel unit test more robust

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -50,7 +50,7 @@ example_url <- function() {
   env_cache(the, "test_app",
     webfakes::new_app_process(
       app,
-      opts = webfakes::server_opts(num_threads = 2)
+      opts = webfakes::server_opts(num_threads = 6, enable_keep_alive = TRUE)
     )
   )
   the$test_app$url()

--- a/tests/testthat/test-multi-req.R
+++ b/tests/testthat/test-multi-req.R
@@ -9,13 +9,9 @@ test_that("correctly prepares request", {
 })
 
 test_that("requests happen in parallel", {
-  # GHA MacOS builder seems to be very slow
-  skip_if(
-    isTRUE(as.logical(Sys.getenv("CI", "false"))) &&
-    Sys.info()[["sysname"]] == "Darwin"
-  )
-
+  # test works best if webfakes has ample threads and keepalive
   reqs <- list2(
+    request_test("/delay/:secs", secs = 0),
     request_test("/delay/:secs", secs = 0.25),
     request_test("/delay/:secs", secs = 0.25),
     request_test("/delay/:secs", secs = 0.25),


### PR DESCRIPTION
Fixes #622. We now enable the test on MacOS, and this will also unblock a cran release for `curl`.