### PR TITLE
Test with dev curl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,3 +54,4 @@ Config/testthat/start-first: resp-stream, req-perform
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Remotes: jeroen/curl

--- a/tests/testthat/test-multi-req.R
+++ b/tests/testthat/test-multi-req.R
@@ -10,6 +10,7 @@ test_that("correctly prepares request", {
 
 test_that("requests happen in parallel", {
   # test works best if webfakes has ample threads and keepalive
+  skip_on_cran()
   reqs <- list2(
     request_test("/delay/:secs", secs = 0),
     request_test("/delay/:secs", secs = 0.25),


### PR DESCRIPTION
Something changed in webfakes which broke the the test again on Windows.

Decided to revert default `CURLOPT_PIPEWAIT` back to false in curl so this is no longer an issue: https://github.com/jeroen/curl/commit/0288b3f37384d0670be39ce37e7c9f35e090a120