### PR TITLE
Tests: run the multi-req tests first

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ VignetteBuilder:
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Config/testthat/parallel: true
-Config/testthat/start-first: resp-stream, req-perform
+Config/testthat/start-first: multi-req, resp-stream, req-perform
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2


### PR DESCRIPTION
This seems to fix the test failures. 

An alternative fix would to stop the example server in the problematic `test_that()` block and start a new one. 

Yet another alternative is to increase the number of threads to (say) 50. (They are started on demand, 50 is only the maximum.)