### PR TITLE
Refine `resp_stream_sse()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `resp_stream_sse()` now automatically retrieves the next event if the current event contains no data. The data is now returned as a single string (#650).
+
 # httr2 1.1.0
 
 ## Lifecycle changes

--- a/R/req-perform-connection.R
+++ b/R/req-perform-connection.R
@@ -23,8 +23,8 @@
 #'   * `0`: no output
 #'   * `1`: show headers
 #'   * `2`: show headers and bodies as they're streamed
-#'   * `3`: show headers, bodies, curl status messages, and stream buffer
-#'     management
+#'   * `3`: show headers, bodies, curl status messages, raw SSEs, and stream
+#'     buffer management
 #'
 #'   Use [with_verbosity()] to control the verbosity of requests that
 #'   you can't affect directly.

--- a/R/resp-stream.R
+++ b/R/resp-stream.R
@@ -90,7 +90,6 @@ resp_stream_lines <- function(resp, lines = 1, max_size = Inf, warn = TRUE) {
 
   if (resp_stream_show_body(resp)) {
     log_stream(lines_read)
-    cli::cat_line()
   }
 
   lines_read
@@ -112,9 +111,9 @@ resp_stream_sse <- function(resp, max_size = Inf) {
 
     if (resp_stream_show_buffer(resp)) {
       log_stream(
-        "Raw server sent event: ----------------------\n",
-        charToRaw(event_bytes),
-        "-----------------------------\n",
+        cli::rule("Raw server sent event"), "\n",
+        rawToChar(event_bytes),
+        prefix = " * "
       )
     }
 
@@ -279,8 +278,9 @@ resp_boundary_pushback <- function(resp, max_size, boundary_func, include_traile
   resp$cache$push_back <- raw()
 
   if (resp_stream_show_buffer(resp)) {
+    log_stream(cli::rule("Buffer"), prefix = " * ")
     print_buffer <- function(buf, label) {
-      cli::cat_line(" * ", label, ": ", paste(as.character(buf), collapse = " "))
+      log_stream(label, ": ", paste(as.character(buf), collapse = " "), prefix = " * ")
     }
   } else {
     print_buffer <- function(buf, label) {}

--- a/man/req_perform_connection.Rd
+++ b/man/req_perform_connection.Rd
@@ -19,8 +19,8 @@ around \code{\link[=req_verbose]{req_verbose()}} that uses an integer to control
 \item \code{0}: no output
 \item \code{1}: show headers
 \item \code{2}: show headers and bodies as they're streamed
-\item \code{3}: show headers, bodies, curl status messages, and stream buffer
-management
+\item \code{3}: show headers, bodies, curl status messages, raw SSEs, and stream
+buffer management
 }
 
 Use \code{\link[=with_verbosity]{with_verbosity()}} to control the verbosity of requests that

--- a/man/resp_stream_raw.Rd
+++ b/man/resp_stream_raw.Rd
@@ -40,7 +40,9 @@ EOL.}
 \itemize{
 \item \code{resp_stream_raw()}: a raw vector.
 \item \code{resp_stream_lines()}: a character vector.
-\item \code{resp_stream_sse()}: a list with components \code{type}, \code{data}, and \code{id}
+\item \code{resp_stream_sse()}: a list with components \code{type}, \code{data}, and \code{id}.
+\code{type}, \code{data}, and \code{id} are always strings; \code{data} and \code{id} may be empty
+strings.
 \item \code{resp_stream_aws()}: a list with components \code{headers} and \code{body}.
 \code{body} will be automatically parsed if the event contents a \verb{:content-type}
 header with \code{application/json}.

--- a/tests/testthat/_snaps/resp-stream.md
+++ b/tests/testthat/_snaps/resp-stream.md
@@ -20,9 +20,7 @@
       stream_all(req, resp_stream_lines, 1)
     Output
       << line 1
-      
       << line 2
-      
     Code
       stream_all(req, resp_stream_raw, 5 / 1024)
     Output
@@ -40,6 +38,7 @@
         resp_stream_lines(con, 1)
       }
     Output
+       * -- Buffer ----------------------------------------------------------------------
        * Buffer to parse: 
        * Received chunk: 6c 69 6e 65 20 31 0a 6c 69 6e 65 20 32 0a
        * Combined buffer: 6c 69 6e 65 20 31 0a 6c 69 6e 65 20 32 0a
@@ -47,10 +46,38 @@
        * Matched data: 6c 69 6e 65 20 31 0a
        * Remaining buffer: 6c 69 6e 65 20 32 0a
       << line 1
-      
+       * -- Buffer ----------------------------------------------------------------------
        * Buffer to parse: 6c 69 6e 65 20 32 0a
        * Matched data: 6c 69 6e 65 20 32 0a
        * Remaining buffer: 
       << line 2
+
+# verbosity = 3 shows raw sse events
+
+    Code
+      . <- resp_stream_sse(resp)
+    Output
+       * -- Buffer ----------------------------------------------------------------------
+       * Buffer to parse: 
+       * Received chunk: 3a 20 63 6f 6d 6d 65 6e 74 0a 0a 64 61 74 61 3a 20 31 0a 0a
+       * Combined buffer: 3a 20 63 6f 6d 6d 65 6e 74 0a 0a 64 61 74 61 3a 20 31 0a 0a
+       * Buffer to parse: 3a 20 63 6f 6d 6d 65 6e 74 0a 0a 64 61 74 61 3a 20 31 0a 0a
+       * Matched data: 3a 20 63 6f 6d 6d 65 6e 74 0a 0a
+       * Remaining buffer: 64 61 74 61 3a 20 31 0a 0a
+       * -- Raw server sent event -------------------------------------------------------
+       * : comment
+       * 
+       * 
+       * -- Buffer ----------------------------------------------------------------------
+       * Buffer to parse: 64 61 74 61 3a 20 31 0a 0a
+       * Matched data: 64 61 74 61 3a 20 31 0a 0a
+       * Remaining buffer: 
+       * -- Raw server sent event -------------------------------------------------------
+       * data: 1
+       * 
+       * 
+      << type: message
+      << data: 1
+      << id: 
       
 

--- a/tests/testthat/test-resp-stream.R
+++ b/tests/testthat/test-resp-stream.R
@@ -341,6 +341,16 @@ test_that("verbosity = 3 shows buffer info", {
   )
 })
 
+test_that("verbosity = 3 shows raw sse events", {
+  req <- local_app_request(function(req, res) {
+    res$send_chunk(": comment\n\n")
+    res$send_chunk("data: 1\n\n")
+  })
+
+  resp <- req_perform_connection(req, verbosity = 3)
+  withr::defer(close(resp))
+  expect_snapshot(. <- resp_stream_sse(resp))
+})
 
 test_that("has a working find_event_boundary", {
   boundary_test <- function(x, matched, remaining) {


### PR DESCRIPTION
It's a bit difficult to translate the spec to the behaviour that we should implement, but I think this bullet:

> If the data buffer is an empty string, set the data buffer and the event type buffer to the empty string and return.

Implies that if the event has no data, we should automatically wait for an event with data. This allows APIs to stream SSEs containing only comments to keep the stream alive. I think it makes sense to handle this hear, rather than  requiring the end user to deal with it.

`event$data` is also now guaranteed to be a single string, which I think is easier to deal with.

Fixes #650