### PR TITLE
Support dynamic dots in `req_headers_redacted()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_headers_redacted()` supports dynamic dots (#647)
 * `resp_stream_sse()` now automatically retrieves the next event if the current event contains no data. The data is now returned as a single string (#650).
 * `aws_v4_signature()` now works if url contains query parameters (@jeffreyzuber, #645).
 

--- a/R/req-headers.R
+++ b/R/req-headers.R
@@ -82,6 +82,6 @@ req_headers <- function(.req, ..., .redact = NULL) {
 req_headers_redacted <- function(.req, ...) {
   check_request(.req)
 
-  dots <- list(...)
+  dots <- list2(...)
   req_headers(.req, !!!dots, .redact = names(dots))
 }

--- a/tests/testthat/test-req-headers.R
+++ b/tests/testthat/test-req-headers.R
@@ -31,6 +31,7 @@ test_that("can control which headers to redact", {
   expect_redact(req_headers(req, a = 1L, b = 2L, .redact = "a"), "a")
 
   expect_redact(req_headers_redacted(req, a = 1L, b = 2L), c("a", "b"))
+  expect_redact(req_headers_redacted(req, !!!list(a = 1L, b = 2L)), c("a", "b"))
 
   expect_snapshot(error = TRUE, {
     req_headers(req, a = 1L, b = 2L, .redact = 1L)


### PR DESCRIPTION
By using `list2()`. Fixes #647