### PR TITLE
Improve redaction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_headers()` always redacts `Authorization` (#649).
+* `req_headers_redacted()` supports dynamic dots (#647)
 * `resp_stream_sse()` now automatically retrieves the next event if the current event contains no data. The data is now returned as a single string (#650).
 * `aws_v4_signature()` now works if url contains query parameters (@jeffreyzuber, #645).
 

--- a/R/req-auth.R
+++ b/R/req-auth.R
@@ -30,7 +30,7 @@ req_auth_basic <- function(req, username, password = NULL) {
   password <- check_password(password)
 
   username_password <- openssl::base64_encode(paste0(username, ":", password))
-  req_headers(req, Authorization = paste0("Basic ", username_password), .redact = "Authorization")
+  req_headers(req, Authorization = paste0("Basic ", username_password))
 }
 
 #' Authenticate request with bearer token
@@ -57,5 +57,5 @@ req_auth_basic <- function(req, username, password = NULL) {
 req_auth_bearer_token <- function(req, token) {
   check_request(req)
   check_string(token)
-  req_headers(req, Authorization = paste("Bearer", token), .redact = "Authorization")
+  req_headers(req, Authorization = paste("Bearer", token))
 }

--- a/man/req_headers.Rd
+++ b/man/req_headers.Rd
@@ -20,8 +20,8 @@ and their values.
 \item Use a character vector to repeat a header.
 }}
 
-\item{.redact}{Headers to redact. If \code{NULL}, the default, the added headers
-are not redacted.}
+\item{.redact}{A character vector of headers to redact. The Authorization
+header is always redacted.}
 }
 \value{
 A modified HTTP \link{request}.

--- a/tests/testthat/_snaps/req-headers.md
+++ b/tests/testthat/_snaps/req-headers.md
@@ -1,4 +1,15 @@
-# can control which headers to redact
+# is case insensitive
+
+    Code
+      req
+    Message
+      <httr2_request>
+      GET http://example.com
+      Headers:
+      * a: "<REDACTED>"
+      Body: empty
+
+# checks input types
 
     Code
       req_headers(req, a = 1L, b = 2L, .redact = 1L)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,7 @@
 testthat::set_state_inspector(function() {
   list(connections = getAllConnections())
 })
+
+expect_redacted <- function(req, expected) {
+  expect_equal(attr(req$headers, "redact"), expected)
+}

--- a/tests/testthat/test-req-auth.R
+++ b/tests/testthat/test-req-auth.R
@@ -3,6 +3,7 @@ test_that("can send username/password", {
   password <- "p"
   req1 <- request_test("/basic-auth/:user/:password")
   req2 <- req1 %>% req_auth_basic(user, password)
+  expect_redacted(req2, "Authorization")
 
   expect_error(req_perform(req1), class = "httr2_http_401")
   expect_error(req_perform(req2), NA)
@@ -10,5 +11,6 @@ test_that("can send username/password", {
 
 test_that("can send bearer token", {
   req <- req_auth_bearer_token(request_test(), "abc")
+  expect_redacted(req, "Authorization")
   expect_equal(req$headers, structure(list(Authorization = "Bearer abc"), redact = "Authorization"))
 })


### PR DESCRIPTION
* Always redact `Authorization()`. Fixes #649.
* Support dynamic dots in `req_headers_redacted()`  (#647)
* Refactor code
* Refactor tests and add a bunch more.