### PR TITLE
Fix `req_perform_promise()` test

### DIFF
--- a/tests/testthat/helper-promise.R
+++ b/tests/testthat/helper-promise.R
@@ -5,9 +5,7 @@ extract_promise <- function(promise, timeout = 30) {
   promises::then(
     promise,
     onFulfilled = function(value) promise_value <<- value,
-    onRejected = function(reason) {
-      error <<- reason
-    }
+    onRejected = function(reason) error <<- reason
   )
 
   start <- Sys.time()
@@ -15,12 +13,12 @@ extract_promise <- function(promise, timeout = 30) {
     if (difftime(Sys.time(), start, units = "secs") > timeout) {
       stop("Waited too long")
     }
-    later::run_now()
-    Sys.sleep(0.01)
+    later::run_now(0.01)
   }
 
   if (!is.null(error)) {
     cnd_signal(error)
-  } else
+  } else if (is_response(promise_value) && resp_status(promise_value) == 200L) {
     promise_value
+  }
 }

--- a/tests/testthat/test-req-promise.R
+++ b/tests/testthat/test-req-promise.R
@@ -111,7 +111,7 @@ test_that("req_perform_promise uses the default loop", {
   later::with_temp_loop({
     # You can create an async response with explicit pool=NULL, but it can't
     # proceed until the temp loop is over
-    p2 <- req_perform_promise(request_test("/get"), pool = NULL)
+    p2 <- req_perform_promise(request_test("/delay/:secs", secs = 0.25), pool = NULL)
 
     # You can create an async response with explicit pool=pool, and it can
     # proceed as long as that pool was first used inside of the temp loop


### PR DESCRIPTION
An attempt to eliminate failures seen on CI such as this one:
https://github.com/r-lib/httr2/actions/runs/13040834972/job/36382096512?pr=653

Theoretically when calling `req_perform_promise()`, there is an initial call to `curl::multi_run(0)` which may succeed at once, in which case the promise resolves immediately and our test assertion would fail.

EDIT: actually the request doesn't succeed at once, but can rather fail which causes the promise to resolve immediately, in which case the response status code will be something other than 200. We now take into account this possibility in the test helper `extract_promise()`.