### PR TITLE
Really fix `req_perform_promise()` test

### DIFF
--- a/tests/testthat/helper-promise.R
+++ b/tests/testthat/helper-promise.R
@@ -18,7 +18,7 @@ extract_promise <- function(promise, timeout = 30) {
 
   if (!is.null(error)) {
     cnd_signal(error)
-  } else if (is_response(promise_value) && resp_status(promise_value) == 200L) {
+  } else {
     promise_value
   }
 }

--- a/tests/testthat/test-req-promise.R
+++ b/tests/testthat/test-req-promise.R
@@ -106,12 +106,12 @@ test_that("req_perform_promise uses the default loop", {
   # temp loop was created.
 
   # This can't proceed within the temp loop
-  p1 <- req_perform_promise(request_test("/get"))
+  p1 <- req_perform_promise(request_test("/delay/:secs", secs = 0.25))
 
   later::with_temp_loop({
     # You can create an async response with explicit pool=NULL, but it can't
     # proceed until the temp loop is over
-    p2 <- req_perform_promise(request_test("/delay/:secs", secs = 0.25), pool = NULL)
+    p2 <- req_perform_promise(request_test("/get"), pool = NULL)
 
     # You can create an async response with explicit pool=pool, and it can
     # proceed as long as that pool was first used inside of the temp loop

--- a/tests/testthat/test-resp-stream.R
+++ b/tests/testthat/test-resp-stream.R
@@ -337,7 +337,7 @@ test_that("verbosity = 3 shows buffer info", {
         resp_stream_lines(con, 1)
       }
     },
-    transform = function(lines) lines[!grepl("^(<-|->)", lines)]
+    transform = transform_verbose_response
   )
 })
 


### PR DESCRIPTION
Re-attempt of #672 as it subsequently failed here: https://github.com/r-lib/httr2/actions/runs/13227684468/job/36920624133. The possibility of the `p2` request returning an error was faulty logic, as it would have tripped up the later test on line 135.

This partially reverts #672, but re-affirms the initial diagnosis that a request could return immediately.
- My initial fix was to add a delay to `p2`, but in fact I should have done this to `p1`.
- This ensures that there is already a poller for the global pool using the global loop, which remains active.
- This means that when it comes to `p2`, it is added to the global pool, and therefore cannot proceed as it can only be polled by the global loop.