### PR TITLE
Explicitly expose cache object in `req_auth_sign()`

### DIFF
--- a/R/req-auth-aws.R
+++ b/R/req-auth-aws.R
@@ -60,8 +60,7 @@ auth_aws_sign <- function(req,
                           aws_secret_access_key,
                           aws_session_token = NULL,
                           aws_service = NULL,
-                          aws_region = NULL,
-                          reauth = FALSE) {
+                          aws_region = NULL) {
 
   current_time <- Sys.time()
 

--- a/R/req-auth-sign.R
+++ b/R/req-auth-sign.R
@@ -1,20 +1,25 @@
 
-req_auth_sign <- function(req, fun, params) {
+req_auth_sign <- function(req, fun, params, cache) {
   req_policies(req,
     auth_sign = list(
       fun = fun,
-      params = params
+      params = params,
+      cache = cache
     )
   )
 }
-auth_sign <- function(req, reauth = FALSE) {
+auth_sign <- function(req) {
   if (!req_policy_exists(req, "auth_sign")) {
     return(req)
   }
 
   exec(req$policies$auth_sign$fun,
     req = req,
-    reauth = reauth,
+    cache = req$policies$auth_sign$cache,
     !!!req$policies$auth_sign$params
   )
+}
+
+req_auth_clear_cache <- function(req) {
+  req$policies$auth_sign$cache$clear()
 }

--- a/R/req-perform.R
+++ b/R/req-perform.R
@@ -100,7 +100,7 @@ req_perform <- function(
 
   n <- 0
   tries <- 0
-  reauth <- FALSE # only ever re-authenticate once
+  reauthed <- FALSE # only ever re-authenticate once
 
   throttle_delay(req)
 
@@ -117,9 +117,10 @@ req_perform <- function(
       tries <- tries + 1
       delay <- retry_after(req, resp, tries)
       signal(class = "httr2_retry", tries = tries, delay = delay)
-    } else if (!reauth && resp_is_invalid_oauth_token(req, resp)) {
-      reauth <- TRUE
-      req_prep <- req_prepare(req, reauth = TRUE)
+    } else if (!reauthed && resp_is_invalid_oauth_token(req, resp)) {
+      reauthed <- TRUE
+      req_auth_clear_cache(req)
+      req_prep <- req_prepare(req)
       handle <- req_handle(req_prep)
       delay <- 0
     } else {
@@ -128,7 +129,7 @@ req_perform <- function(
     }
   }
   # Used for testing
-  signal(class = "httr2_fetch", n = n, tries = tries, reauth = reauth)
+  signal(class = "httr2_fetch", n = n, tries = tries, reauth = reauthed)
 
   resp <- cache_post_fetch(req, resp, path = path)
   handle_resp(req, resp, error_call = error_call)
@@ -238,8 +239,8 @@ last_request <- function() {
 
 # Must call req_prepare(), then req_handle(), then after the request has been
 # performed, req_completed() (on the prepared requests)
-req_prepare <- function(req, reauth = FALSE) {
-  req <- auth_sign(req, reauth = reauth)
+req_prepare <- function(req) {
+  req <- auth_sign(req)
   req <- req_method_apply(req)
   req <- req_body_apply(req)
   req

--- a/tests/testthat/test-oauth-flow-refresh.R
+++ b/tests/testthat/test-oauth-flow-refresh.R
@@ -9,8 +9,8 @@ test_that("cache considers refresh_token", {
     req_oauth_refresh(client, refresh_token = "rt2")
 
   # cache must be empty
-  expect_equal(req1$policies$auth_sign$params$cache$get(), NULL)
-  expect_equal(req2$policies$auth_sign$params$cache$get(), NULL)
+  expect_equal(req1$policies$auth_sign$cache$get(), NULL)
+  expect_equal(req2$policies$auth_sign$cache$get(), NULL)
 
   # simulate that we made a request and got back a token
   token <- oauth_token(
@@ -21,11 +21,11 @@ test_that("cache considers refresh_token", {
     .date = Sys.time()
   )
   # ... that is now cached
-  req1$policies$auth_sign$params$cache$set(token)
+  req1$policies$auth_sign$cache$set(token)
 
   # req1 cache must be filled, but req2 cache still be empty
-  expect_equal(req1$policies$auth_sign$params$cache$get(), token)
-  expect_equal(req2$policies$auth_sign$params$cache$get(), NULL)
+  expect_equal(req1$policies$auth_sign$cache$get(), token)
+  expect_equal(req2$policies$auth_sign$cache$get(), NULL)
 })
 
 test_that("warns if refresh token changes", {


### PR DESCRIPTION
@atheriel can you please take a look at this? I've implemented with the goal of supporting OAuth re-authentication for `req_perform_parallel()`, but I think it generally decouples concerns a bit more clearly than previously, and it might help with some of the auth stuff that you've been experimenting with.