### PR TITLE
Fixes for covr

### DIFF
--- a/R/resp-stream-aws.R
+++ b/R/resp-stream-aws.R
@@ -129,7 +129,7 @@ type_enum <- function(value) {
     "BYTE_ARRAY",
     "CHARACTER",
     "TIMESTAMP",
-    "UUID",
+    "UUID"
   )
 }
 

--- a/R/test.R
+++ b/R/test.R
@@ -20,7 +20,7 @@ request_test <- function(template = "/get", ...) {
 #' @export
 example_url <- function(path = "/") {
   check_installed("webfakes")
-  if (is_testing() && !is_interactive()) {
+  if (is_testing() && !interactive()) {
     testthat::skip_on_covr()
   }
   env_cache(the, "test_app", example_app())

--- a/tests/testthat/helper-webfakes.R
+++ b/tests/testthat/helper-webfakes.R
@@ -1,7 +1,7 @@
 local_app_request <- function(fun, method = "get", frame = parent.frame()) {
   # Works interactively (useful for manaul coverage checking)
   # but not in separate process
-  if (!is_interactive()) {
+  if (!interactive()) {
     skip_on_covr()
   }
 


### PR DESCRIPTION
* Eliminate trailing comma in switch which causes warning
* Use `interactive()` instead of `is_interactive()` since `is_interactive()` will always be false in tests