### PR TITLE
PoolRequest tweaks

### DIFF
--- a/R/pooled-request.R
+++ b/R/pooled-request.R
@@ -87,6 +87,7 @@ PooledRequest <- R6Class(
     on_failure = NULL,
     on_error = NULL,
 
+    # curl success could be httr2 success or httr2 failure
     succeed = function(curl_data) {
       private$handle <- NULL
       req_completed(private$req_prep)
@@ -112,6 +113,7 @@ PooledRequest <- R6Class(
       }
     },
 
+    # curl failure = httr2 error
     fail = function(msg) {
       private$handle <- NULL
       req_completed(private$req_prep)

--- a/R/req-error.R
+++ b/R/req-error.R
@@ -113,15 +113,18 @@ error_body <- function(req, resp, call = caller_env()) {
   )
 }
 
-capture_curl_error <- function(code) {
+capture_curl_error <- function(code, call = caller_env()) {
   resp <- tryCatch(
     code,
-    error = function(err) {
-      error_cnd(
-        message = "Failed to perform HTTP request.",
-        class = c("httr2_failure", "httr2_error"),
-        parent = err
-      )
-    }
+    error = function(err) curl_cnd(err, call = call)
+  )
+}
+
+curl_cnd <- function(err, call = caller_env()) {
+  error_cnd(
+    message = "Failed to perform HTTP request.",
+    class = c("httr2_failure", "httr2_error"),
+    parent = err,
+    call = call
   )
 }

--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -93,12 +93,12 @@ req_perform_promise <- function(req,
   req <- req_verbosity(req, verbosity)
 
   promises::promise(function(resolve, reject) {
-    pooled_req <- PooledRequest$new(
+    pooled_req <- pooled_request(
       req = req,
       path = path,
-      on_success = function(resp, tries) resolve(resp),
-      on_failure = function(error, tries) reject(error),
-      on_error = function(error, tries) reject(error)
+      on_success = function(resp) resolve(resp),
+      on_failure = function(error) reject(error),
+      on_error = function(error) reject(error)
     )
     pooled_req$submit(pool)
     ensure_pool_poller(pool, reject)

--- a/tests/testthat/_snaps/req-perform-parallel.md
+++ b/tests/testthat/_snaps/req-perform-parallel.md
@@ -17,6 +17,8 @@
       req_perform_parallel(reqs[2])
     Condition
       Error in `req_perform_parallel()`:
+      ! Failed to perform HTTP request.
+      Caused by error:
       ! Could not resolve host: INVALID
 
 # req_perform_parallel respects http_error() body message


### PR DESCRIPTION
* Eliminate unused `tries` argument. (Since users can track themselves, if needed)
* Wrap curl errors in a httr2 for consistency with `req_perform()`
* Use `pooled_request()`