### PR TITLE
Avoid partial matching of "refresh_token"

### DIFF
--- a/R/oauth-token.R
+++ b/R/oauth-token.R
@@ -80,6 +80,6 @@ token_refresh <- function(client, refresh_token, scope = NULL, token_params = li
     scope = scope,
     !!!token_params
   )
-  out[["refresh_token"]] <- out[["refresh_token"]] %||% refresh_token
+  out$refresh_token <- out[["refresh_token"]] %||% refresh_token
   out
 }

--- a/R/oauth-token.R
+++ b/R/oauth-token.R
@@ -80,6 +80,6 @@ token_refresh <- function(client, refresh_token, scope = NULL, token_params = li
     scope = scope,
     !!!token_params
   )
-  out$refresh_token <- out$refresh_token %||% refresh_token
+  out[["refresh_token"]] <- out[["refresh_token"]] %||% refresh_token
   out
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -251,7 +251,7 @@ create_progress_bar <- function(total,
     )
   }
 
-  args$name <- args$name %||% name
+  args$name <- args[["name"]] %||% name
   # Can be removed if https://github.com/r-lib/cli/issues/630 is fixed
   if (is.infinite(total)) {
     total <- NA


### PR DESCRIPTION
See #696 for the full description of why this is an issue here, but the same "editing a list that we don't fully own" issue could be important in a lot of other places in this package.

A global search for `\w+\$\w+\s*<-` finds a ton of results. Is there a way to make this safer globally?

Closes #696.