### PR TITLE
Upgrade to curl 6.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     R (>= 4.0)
 Imports:
     cli (>= 3.0.0),
-    curl (>= 6.2.0),
+    curl (>= 6.2.1),
     glue,
     lifecycle,
     magrittr,

--- a/R/pooled-request.R
+++ b/R/pooled-request.R
@@ -118,7 +118,8 @@ PooledRequest <- R6Class(
       private$handle <- NULL
       req_completed(private$req_prep)
 
-      curl_error <- error_cnd(message = msg, class = "curl_error", call = NULL)
+      error_class <- setdiff(class(msg), "character")
+      curl_error <- error_cnd(message = msg, class = error_class, call = NULL)
       error <- curl_cnd(curl_error, call = private$error_call)
       error$request <- self$req
       private$on_error(error)

--- a/R/req-dry-run.R
+++ b/R/req-dry-run.R
@@ -7,7 +7,6 @@
 #'
 #' ## Limitations
 #'
-#' * The `Host` header is not respected.
 #' * The HTTP version is always `HTTP/1.1` (since you can't determine what it
 #'   will actually be without connecting to the real server).
 #'

--- a/man/req_dry_run.Rd
+++ b/man/req_dry_run.Rd
@@ -50,7 +50,6 @@ the magic of \code{\link[curl:curl_echo]{curl::curl_echo()}}.
 \details{
 \subsection{Limitations}{
 \itemize{
-\item The \code{Host} header is not respected.
 \item The HTTP version is always \code{HTTP/1.1} (since you can't determine what it
 will actually be without connecting to the real server).
 }

--- a/tests/testthat/_snaps/req-perform-parallel.md
+++ b/tests/testthat/_snaps/req-perform-parallel.md
@@ -6,21 +6,6 @@
       Error in `req_perform_parallel()`:
       ! If supplied, `paths` must be the same length as `req`.
 
-# errors by default
-
-    Code
-      req_perform_parallel(reqs[1])
-    Condition
-      Error in `req_perform_parallel()`:
-      ! HTTP 404 Not Found.
-    Code
-      req_perform_parallel(reqs[2])
-    Condition
-      Error in `req_perform_parallel()`:
-      ! Failed to perform HTTP request.
-      Caused by error:
-      ! Could not resolve host: INVALID
-
 # req_perform_parallel respects http_error() body message
 
     Code

--- a/tests/testthat/test-req-perform-parallel.R
+++ b/tests/testthat/test-req-perform-parallel.R
@@ -89,14 +89,14 @@ test_that("immutable objects retrieved from cache", {
 
 test_that("errors by default", {
   req <- request_test("/status/:status", status = 404)
-  cnd <- expect_error(req_perform_parallel(list(req)))
-  expect_s3_class(cnd, "httr2_http_404")
+  err <- expect_error(req_perform_parallel(list(req)))
+  expect_s3_class(err, "httr2_http_404")
 
   # Wraps and forwards curl errors
   req <- request("INVALID")
-  cnd <- expect_error(req_perform_parallel(list(req)))
+  err <- expect_error(req_perform_parallel(list(req)))
   expect_s3_class(err, "httr2_failure")
-  expect_s3_class(err$parent, "curl_error_unsupported_protocol")
+  expect_s3_class(err$parent, "curl_error_couldnt_resolve_host")
 })
 
 test_that("both curl and HTTP errors become errors on continue", {

--- a/tests/testthat/test-req-perform-parallel.R
+++ b/tests/testthat/test-req-perform-parallel.R
@@ -88,14 +88,15 @@ test_that("immutable objects retrieved from cache", {
 })
 
 test_that("errors by default", {
-  reqs <- list2(
-    request_test("/status/:status", status = 404),
-    request("INVALID")
-  )
-  expect_snapshot(error = TRUE, {
-    req_perform_parallel(reqs[1])
-    req_perform_parallel(reqs[2])
-  })
+  req <- request_test("/status/:status", status = 404)
+  cnd <- expect_error(req_perform_parallel(list(req)))
+  expect_s3_class(cnd, "httr2_http_404")
+
+  # Wraps and forwards curl errors
+  req <- request("INVALID")
+  cnd <- expect_error(req_perform_parallel(list(req)))
+  expect_s3_class(err, "httr2_failure")
+  expect_s3_class(err$parent, "curl_error_unsupported_protocol")
 })
 
 test_that("both curl and HTTP errors become errors on continue", {


### PR DESCRIPTION
* Remove `Host` limitation in `req_dry_run()`. Fixes #694
* Use curl error class. Fixes #693.
* Replace snapshot test with something more precise