### PR TITLE
Fix #705: Error with AWS signing: argument "cache" is missing, with no default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # httr2 (development version)
 
+## Minor improvements and bug fixes
+
+* AWS request signing was failing with an "argument 'cache' is missing" error (#706).
+
 # httr2 1.1.1
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # httr2 (development version)
 
-## Minor improvements and bug fixes
-
-* AWS request signing was failing with an "argument 'cache' is missing" error (#706).
+* Fix AWS request signing due to `argument 'cache' is missing` error (#706, @jcheng5).
 
 # httr2 1.1.1
 

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -142,15 +142,15 @@ cache_choose <- function(client, cache_disk = FALSE, cache_key = NULL) {
   }
 }
 
+# Used for auth endoints that don't have a cache
 cache_noop <- function() {
-  # Does nothing.
   list(
     get = function() {
-      warn("get() was called on cache_noop")
+      abort("get() was called on cache_noop")
       invisible()
     },
     set = function(token) {
-      warn("set() was called on cache_noop")
+      abort("set() was called on cache_noop")
       invisible()
     },
     clear = function() {}

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -142,6 +142,20 @@ cache_choose <- function(client, cache_disk = FALSE, cache_key = NULL) {
   }
 }
 
+cache_noop <- function() {
+  # Does nothing.
+  list(
+    get = function() {
+      warn("get() was called on cache_noop")
+      invisible()
+    },
+    set = function(token) {
+      warn("set() was called on cache_noop")
+      invisible()
+    },
+    clear = function() {}
+  )
+}
 cache_mem <- function(client, key = NULL) {
   key <- hash(c(client$name, key))
   list(

--- a/R/req-auth-aws.R
+++ b/R/req-auth-aws.R
@@ -51,7 +51,10 @@ req_auth_aws_v4 <- function(req,
       aws_session_token = aws_session_token,
       aws_service = aws_service,
       aws_region = aws_region
-    )
+    ),
+    # auth_aws_sign doesn't have anything to cache, but still need to provide
+    # a cache argument because the req_auth_sign machinery expects it
+    cache = cache_noop()
   )
 }
 
@@ -60,7 +63,8 @@ auth_aws_sign <- function(req,
                           aws_secret_access_key,
                           aws_session_token = NULL,
                           aws_service = NULL,
-                          aws_region = NULL) {
+                          aws_region = NULL,
+                          cache) {
 
   current_time <- Sys.time()
 

--- a/tests/testthat/test-req-auth-aws.R
+++ b/tests/testthat/test-req-auth-aws.R
@@ -1,4 +1,17 @@
-test_that("can correctly sign a request", {
+test_that("can correctly sign a request with dummy credentials", {
+  req <- request("https://sts.amazonaws.com/")
+  req <- req_auth_aws_v4(req,
+    aws_access_key_id = "AKIAIOSFODNN7EXAMPLE",
+    aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  )
+  req <- req_body_form(req, Action = "GetCallerIdentity", Version = "2011-06-15")
+  expect_error(req_perform(req), class = "httr2_http_403")
+
+  # And can clear non-existant cache
+  expect_no_error(req_auth_clear_cache(req))
+})
+
+test_that("can correctly sign a request with live credentials", {
   skip_if_not(has_paws_credentials())
   creds <- paws.common::locate_credentials()
 


### PR DESCRIPTION
Fixes #705; necessary for ellmer to work with Bedrock.