### PR TITLE
Update `with_mocked_responses` to use new name in docs

### DIFF
--- a/R/req-mock.R
+++ b/R/req-mock.R
@@ -17,7 +17,7 @@
 #'
 #' @param code Code to execute in the temporary environment.
 #' @param env Environment to use for scoping changes.
-#' @returns `with_mock()` returns the result of evaluating `code`.
+#' @returns `with_mocked_responses()` returns the result of evaluating `code`.
 #' @export
 #' @examples
 #' # This function should perform a response against google.com:
@@ -30,7 +30,7 @@
 #' my_mock <- function(req) {
 #'   response(status_code = 403)
 #' }
-#' try(with_mock(my_mock, google()))
+#' try(with_mocked_responses(my_mock, google()))
 with_mocked_responses <- function(mock, code) {
   mock <- as_mock_function(mock)
   withr::with_options(list(httr2_mock = mock), code)

--- a/man/with_mocked_responses.Rd
+++ b/man/with_mocked_responses.Rd
@@ -27,7 +27,7 @@ handle the request) or a \link{response} (if it does).
 \item{env}{Environment to use for scoping changes.}
 }
 \value{
-\code{with_mock()} returns the result of evaluating \code{code}.
+\code{with_mocked_responses()} returns the result of evaluating \code{code}.
 }
 \description{
 Mocking allows you to selectively and temporarily replace the response
@@ -45,5 +45,5 @@ google <- function() {
 my_mock <- function(req) {
   response(status_code = 403)
 }
-try(with_mock(my_mock, google()))
+try(with_mocked_responses(my_mock, google()))
 }


### PR DESCRIPTION
The docs for `with_mocked_responses` still use `with_mock` in the examples / return values, which had me confused for a moment when using these today.

I think it makes sense to use the non-deprecated name instead? This PR replaces `with_mock` with `with_mocked_responses` in the roxygen comments.