### PR TITLE
re-calculate n lengths after exploding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `multi_dots()` now re-calculates n lengths when using `.multi = "explode"` to avoid select/recycling issues (@Kevanness, #719).
+
 # httr2 1.1.2
 
 * `req_headers()` more carefully checks its input types (#707).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # httr2 (development version)
 
-* `multi_dots()` now re-calculates n lengths when using `.multi = "explode"` to avoid select/recycling issues (@Kevanness, #719).
+* `req_url_query()` now re-calculates n lengths when using `.multi = "explode"` to avoid select/recycling issues (@Kevanness, #719).
 
 # httr2 1.1.2
 

--- a/R/utils-multi.R
+++ b/R/utils-multi.R
@@ -64,13 +64,7 @@ multi_dots <- function(
       dots[n > 1] <- lapply(dots[n > 1], I)
     } else if (.multi == "explode") {
       dots <- explode(dots)
-      dots[n > 1] <- imap(
-        dots[n > 1],
-        format_query_param,
-        multi = TRUE,
-        form = form
-      )
-      dots[n > 1] <- lapply(dots[n > 1], I)
+      n <- lengths(dots)
     } else if (.multi == "error") {
       cli::cli_abort(
         c(

--- a/tests/testthat/test-utils-multi.R
+++ b/tests/testthat/test-utils-multi.R
@@ -17,6 +17,25 @@ test_that("can handle multi query params", {
   )
 })
 
+test_that("can handle mixed length multi query params", {
+  expect_equal(
+    multi_dots(a = 1:2, b = 1, c = NULL, .multi = "explode"),
+    list(a = I("1"), a = I("2"), b = I("1"), c = NULL)
+  )
+  expect_equal(
+    multi_dots(a = 1:2, b = 1, c = NULL, .multi = "comma"),
+    list(a = I("1,2"), b = I("1"), c = NULL)
+  )
+  expect_equal(
+    multi_dots(a = 1:2, b = 1, c = NULL, .multi = "pipe"),
+    list(a = I("1|2"), b = I("1"), c = NULL)
+  )
+  expect_equal(
+    multi_dots(a = 1:2, b = 1, c = NULL, .multi = function(x) "X"),
+    list(a = I("X"), b = I("1"), c = NULL)
+  )
+})
+
 test_that("can opt-out of escaping for' vectors", {
   expect_equal(
     multi_dots(a = I(c(" ", " ")), .multi = "comma"),


### PR DESCRIPTION
Closes #719

- Add a test for mixed length query params
- Replace handling of n > 1 in .explode with re-calculating lengths.