### PR TITLE
Get method from curl_data

### DIFF
--- a/R/resp.R
+++ b/R/resp.R
@@ -106,7 +106,7 @@ new_response <- function(
 
 create_response <- function(req, curl_data, body) {
   the$last_response <- new_response(
-    method = req_method_get(req),
+    method = curl_data$method,
     url = curl_data$url,
     status_code = curl_data$status_code,
     headers = as_headers(curl_data$headers),

--- a/tests/testthat/test-req-perform-parallel.R
+++ b/tests/testthat/test-req-perform-parallel.R
@@ -12,6 +12,15 @@ test_that("can perform a single request", {
   resps <- req_perform_parallel(reqs)
   expect_type(resps, "list")
   expect_length(resps, 1)
+
+  resp <- resps[[1]]
+  expect_s3_class(resp, "httr2_response")
+  expect_equal(resp$method, "GET")
+  expect_equal(resp$url, example_url("/get"))
+  expect_equal(resp$status_code, 200)
+  expect_s3_class(resp$headers, "httr2_headers")
+  expect_type(resp$body, "raw")
+  expect_equal(resp$request, reqs[[1]])
 })
 
 test_that("requests happen in parallel", {

--- a/tests/testthat/test-req-perform.R
+++ b/tests/testthat/test-req-perform.R
@@ -1,8 +1,28 @@
-test_that("success request returns response", {
+test_that("successful request returns expected response", {
   req <- request_test()
   resp <- req_perform(req)
+
   expect_s3_class(resp, "httr2_response")
+  expect_equal(resp$method, "GET")
+  expect_equal(resp$url, example_url("/get"))
+  expect_equal(resp$status_code, 200)
+  expect_s3_class(resp$headers, "httr2_headers")
+  expect_type(resp$body, "raw")
   expect_equal(resp$request, req)
+})
+
+test_that("request updates last_response()", {
+  req200 <- request_test()
+  req404 <- request_test("/404")
+
+  resp <- req_perform(req200)
+  expect_equal(last_response(), resp)
+  expect_equal(last_request(), req200)
+
+  # even if it errors
+  try(req_perform(req404), silent = TRUE)
+  expect_equal(last_response()$status_code, 404)
+  expect_equal(last_request(), req404)
 })
 
 test_that("curl errors become errors", {


### PR DESCRIPTION
And add more tests

This requires [CURLINFO_EFFECTIVE_METHOD](https://curl.se/libcurl/c/CURLINFO_EFFECTIVE_METHOD.html), which was added in 7.72.0, released almost 5 years ago, so should be available in all supported distros.

cc @arcresu