### PR TITLE
Clarify body types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_body_json_modify()` can now be used on a request with an empty body.
 * `req_url_query()` now re-calculates n lengths when using `.multi = "explode"` to avoid select/recycling issues (@Kevanness, #719).
 
 # httr2 1.1.2

--- a/R/req-body.R
+++ b/R/req-body.R
@@ -55,16 +55,13 @@ NULL
 #' @param body A literal string or raw vector to send as body.
 req_body_raw <- function(req, body, type = NULL) {
   check_request(req)
-  if (!is.raw(body) && !is_string(body)) {
+  if (is.raw(body)) {
+    req_body(req, data = body, type = "raw", content_type = type %||% "")
+  } else if (is_string(body)) {
+    req_body(req, data = body, type = "string", content_type = type %||% "")
+  } else {
     cli::cli_abort("{.arg body} must be a raw vector or string.")
   }
-
-  req_body(
-    req,
-    data = body,
-    type = "raw",
-    content_type = type %||% ""
-  )
 }
 
 #' @export
@@ -73,16 +70,12 @@ req_body_raw <- function(req, body, type = NULL) {
 req_body_file <- function(req, path, type = NULL) {
   check_request(req)
   if (!file.exists(path)) {
-    cli::cli_abort("{.arg path} ({.path {path}}) does not exist.")
+    cli::cli_abort("Can't find file {.path {path}}.")
+  } else if (dir.exists(path)) {
+    cli::cli_abort("{.arg path} must be a file, not a directory.")
   }
 
-  # Need to override default content-type "application/x-www-form-urlencoded"
-  req_body(
-    req,
-    data = new_path(path),
-    type = "raw-file",
-    content_type = type %||% ""
-  )
+  req_body(req, data = path, type = "file", content_type = type %||% "")
 }
 
 #' @export
@@ -126,11 +119,11 @@ req_body_json <- function(
 #' @rdname req_body
 req_body_json_modify <- function(req, ...) {
   check_request(req)
-  if (req$body$type != "json") {
-    cli::cli_abort("Can only be used after {.fn req_body_json")
+  if (!req_body_type(req) %in% c("empty", "json")) {
+    cli::cli_abort("Can only be used after {.fn req_body_json}.")
   }
 
-  req$body$data <- utils::modifyList(req$body$data, list2(...))
+  req$body$data <- utils::modifyList(req$body$data %||% list(), list2(...))
   req
 }
 
@@ -159,12 +152,7 @@ req_body_form <- function(
 
   dots <- multi_dots(..., .multi = .multi)
   data <- modify_list(.req$body$data, !!!dots)
-  req_body(
-    .req,
-    data = data,
-    type = "form",
-    content_type = "application/x-www-form-urlencoded"
-  )
+  req_body(.req, data = data, type = "form")
 }
 
 #' @export
@@ -174,12 +162,7 @@ req_body_multipart <- function(.req, ...) {
 
   data <- modify_list(.req$body$data, ...)
   # data must be character, raw, curl::form_file, or curl::form_data
-  req_body(
-    .req,
-    data = data,
-    type = "multipart",
-    content_type = NULL
-  )
+  req_body(.req, data = data, type = "multipart")
 }
 
 # General structure -------------------------------------------------------
@@ -188,10 +171,13 @@ req_body <- function(
   req,
   data,
   type,
-  content_type,
+  content_type = NULL,
   params = list(),
   error_call = parent.frame()
 ) {
+  arg_match(type, c("raw", "string", "file", "json", "form", "multipart"))
+  check_string(content_type, allow_null = TRUE, call = error_call)
+
   if (!is.null(req$body) && req$body$type != type) {
     cli::cli_abort(
       c(
@@ -211,94 +197,86 @@ req_body <- function(
   req
 }
 
-req_body_info <- function(req) {
-  if (is.null(req$body)) {
-    "empty"
-  } else {
-    data <- req$body$data
-    if (is.raw(data)) {
-      glue("{length(data)} bytes of raw data")
-    } else if (is_string(data)) {
-      glue("a string")
-    } else if (is_path(data)) {
-      glue("path '{data}'")
-    } else if (is.list(data)) {
-      glue("{req$body$type} encoded data")
-    } else {
-      "invalid"
-    }
-  }
+req_body_type <- function(req) {
+  req$body$type %||% "empty"
 }
 
-req_body_get <- function(req) {
-  if (is.null(req$body)) {
-    return("")
-  }
+req_body_info <- function(req) {
   switch(
-    req$body$type,
+    req_body_type(req),
+    empty = "empty",
+    raw = glue("a {length(req$body$data)} byte raw vector"),
+    string = "a string",
+    file = glue("a path '{req$body$data}'"),
+    json = "JSON data",
+    form = "form data",
+    multipart = "multipart data"
+  )
+}
+req_body_get <- function(req) {
+  switch(
+    req_body_type(req),
+    empty = NULL,
     raw = req$body$data,
-    form = {
-      data <- unobfuscate(req$body$data)
-      url_query_build(data)
-    },
-    json = exec(jsonlite::toJSON, req$body$data, !!!req$body$params),
-    cli::cli_abort("Unsupported request body type {.str {req$body$type}}.")
+    string = req$body$data,
+    file = readBin(req$body$data, "raw", n = file.size(req$body$data)),
+    json = unclass(exec(jsonlite::toJSON, req$body$data, !!!req$body$params)),
+    form = url_query_build(unobfuscate(req$body$data)),
+    multipart = {
+      # This is a bit clumsy because it requires performing a real request,
+      # which is currently a bit slow and requires httpuv
+      # https://github.com/jeroen/curl/issues/388
+      handle <- req_handle(req_body_apply(req))
+      echo <- curl::curl_echo(handle, progress = FALSE)
+      rawToChar(echo$body)
+    }
   )
 }
 
 req_body_apply <- function(req) {
-  if (is.null(req$body)) {
-    return(req)
+  req <- switch(
+    req_body_type(req),
+    empty = req,
+    raw = req_body_apply_raw(req, req$body$data),
+    string = req_body_apply_string(req, req$body$data),
+    file = req_body_apply_connection(req, req$body$data),
+    json = req_body_apply_string(req, req_body_get(req)),
+    form = req_body_apply_string(req, req_body_get(req)),
+    multipart = req_body_apply_multipart(req, req$body$data),
+  )
+
+  # Set Content-Type if not already set
+  if (!is.null(req$body$content_type) && is.null(req$headers$`Content-Type`)) {
+    req <- req_headers(req, `Content-Type` = req$body$content_type)
   }
-
-  data <- req$body$data
-  type <- req$body$type
-
-  if (type == "raw-file") {
-    size <- file.info(data)$size
-    # Only open connection if needed
-    delayedAssign("con", file(data, "rb"))
-
-    req <- req_policies(
-      req,
-      done = function() close(con)
-    )
-    req <- req_options(
-      req,
-      post = TRUE,
-      readfunction = function(nbytes, ...) readBin(con, "raw", nbytes),
-      seekfunction = function(offset, ...) seek(con, where = offset),
-      postfieldsize_large = size
-    )
-  } else if (type == "raw") {
-    req <- req_body_apply_raw(req, data)
-  } else if (type == "json") {
-    req <- req_body_apply_raw(req, req_body_get(req))
-  } else if (type == "multipart") {
-    data <- unobfuscate(data)
-    req$fields <- data
-  } else if (type == "form") {
-    req <- req_body_apply_raw(req, req_body_get(req))
-  } else {
-    cli::cli_abort("Unsupported request body {.arg type}.", .internal = TRUE)
-  }
-
-  # Respect existing Content-Type if set
-  type_idx <- match("content-type", tolower(names(req$headers)))
-  if (!is.na(type_idx)) {
-    content_type <- req$headers[[type_idx]]
-    req$headers <- req$headers[-type_idx]
-  } else {
-    content_type <- req$body$content_type
-  }
-  req <- req_headers(req, `Content-Type` = content_type)
 
   req
 }
+req_body_apply_string <- function(req, data) {
+  req_body_apply_raw(req, charToRaw(enc2utf8(data)))
+}
+req_body_apply_raw <- function(req, data) {
+  req_options(req, post = TRUE, postfieldsize = length(data), postfields = data)
+}
+req_body_apply_connection <- function(req, data) {
+  size <- file.info(data)$size
+  # Only open connection if needed
+  delayedAssign("con", file(data, "rb"))
 
-req_body_apply_raw <- function(req, body) {
-  if (is_string(body)) {
-    body <- charToRaw(enc2utf8(body))
-  }
-  req_options(req, post = TRUE, postfieldsize = length(body), postfields = body)
+  req <- req_policies(
+    req,
+    done = function() close(con)
+  )
+  req <- req_options(
+    req,
+    post = TRUE,
+    readfunction = function(nbytes, ...) readBin(con, "raw", nbytes),
+    seekfunction = function(offset, ...) seek(con, where = offset),
+    postfieldsize_large = size
+  )
+  req
+}
+req_body_apply_multipart <- function(req, data) {
+  req$fields <- unobfuscate(req$body$data)
+  req
 }

--- a/R/req-dry-run.R
+++ b/R/req-dry-run.R
@@ -82,6 +82,7 @@ req_dry_run <- function(
   invisible(list(
     method = resp$method,
     path = resp$path,
+    body = resp$body,
     headers = as.list(resp$headers)
   ))
 }

--- a/tests/testthat/_snaps/req-body.md
+++ b/tests/testthat/_snaps/req-body.md
@@ -1,10 +1,32 @@
+# can't change body type
+
+    Code
+      req %>% req_body_json(list(x = 1))
+    Condition
+      Error in `req_body_json()`:
+      ! Can't change body type from raw to json.
+      i You must use only one type of `req_body_*()` per request.
+
+# can't send anything else
+
+    Code
+      req_body_raw(req, 1)
+    Condition
+      Error in `req_body_raw()`:
+      ! `body` must be a raw vector or string.
+
 # errors if file doesn't exist
 
     Code
-      req_body_file(request_test(), "doesntexist", type = "text/plain")
+      req_body_file(request_test(), "doesntexist")
     Condition
       Error in `req_body_file()`:
-      ! `path` ('doesntexist') does not exist.
+      ! Can't find file 'doesntexist'.
+    Code
+      req_body_file(request_test(), ".")
+    Condition
+      Error in `req_body_file()`:
+      ! `path` must be a file, not a directory.
 
 # non-json type errors
 
@@ -15,12 +37,26 @@
       ! Unexpected content type "application/xml".
       * Expecting type "application/json" or suffix "json".
 
-# can't change body type
+# can't modify non-json data
 
     Code
-      req %>% req_body_json(list(x = 1))
+      req_body_json_modify(req, a = 1)
     Condition
-      Error in `req_body_json()`:
-      ! Can't change body type from raw to json.
-      i You must use only one type of `req_body_*()` per request.
+      Error in `req_body_json_modify()`:
+      ! Can only be used after `req_body_json()`.
+
+# can send named elements as multipart
+
+    Code
+      cat(req_body_get(req))
+    Output
+      ---{id}
+      Content-Disposition: form-data; name="a"
+      
+      1
+      ---{id}
+      Content-Disposition: form-data; name="b"
+      
+      2
+      ---{id}
 

--- a/tests/testthat/_snaps/req.md
+++ b/tests/testthat/_snaps/req.md
@@ -18,7 +18,7 @@
     Message
       <httr2_request>
       POST https://example.com
-      Body: multipart encoded data
+      Body: multipart data
 
 # printing headers works with {}
 

--- a/tests/testthat/test-req-auth-aws.R
+++ b/tests/testthat/test-req-auth-aws.R
@@ -41,7 +41,7 @@ test_that('aws_v4_signature calculates correct signature', {
   req <- request("https://example.execute-api.us-east-1.amazonaws.com/v0/") %>%
     req_method('POST')
 
-  body_sha256 <- openssl::sha256(req_body_get(req))
+  body_sha256 <- openssl::sha256(req_body_get(req) %||% "")
   current_time <- as.POSIXct(1737483742, origin = "1970-01-01", tz = "EST")
 
   signature <- aws_v4_signature(

--- a/tests/testthat/test-req-dry-run.R
+++ b/tests/testthat/test-req-dry-run.R
@@ -19,7 +19,7 @@ test_that("body is shown", {
   expect_snapshot(req_dry_run(req_json, pretty_json = FALSE))
 
   # doesn't show binary data
-  req_binary <- req_body_raw(req, "Cenário")
+  req_binary <- req_body_raw(req, charToRaw("Cenário"))
   expect_snapshot(req_dry_run(req_binary))
 })
 


### PR DESCRIPTION
General refactoring of code and tests in prepation for #718. It should now be much clearer what sorts of body types are permissible. Includes a few small improvements to error messages which I noticed while adding additional tests to get to 100% test coverage.