### PR TITLE
Add interrupts escape hatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* Functions that capture interrutps (like `req_perform_parallel()` and friends) are now easier to escape if they're called inside a loop: you can press Ctrl + C twice to guarantee an exit (#1810).
 * New `last_request_json()` and `last_response_json()` to conveniently see JSON bodies (#734).
 * `req_body_json_modify()` can now be used on a request with an empty body.
 * `resp_timing()` exposes timing information about the request measured by libcurl (@arcresu, #725).

--- a/R/httr2-package.R
+++ b/R/httr2-package.R
@@ -17,3 +17,4 @@ the$token_cache <- new_environment()
 the$last_response <- NULL
 the$last_request <- NULL
 the$pool_pollers <- new_environment()
+the$last_interrupt <- .POSIXct(-Inf)

--- a/R/httr2-package.R
+++ b/R/httr2-package.R
@@ -17,4 +17,4 @@ the$token_cache <- new_environment()
 the$last_response <- NULL
 the$last_request <- NULL
 the$pool_pollers <- new_environment()
-the$last_interrupt <- .POSIXct(-Inf)
+the$last_interrupt <- 0

--- a/R/req-perform-iterative.R
+++ b/R/req-perform-iterative.R
@@ -181,6 +181,8 @@ req_perform_iterative <- function(
       }
     },
     interrupt = function(cnd) {
+      check_repeated_interrupt()
+
       # interrupt might occur after i was incremented
       if (is.null(resps[[i]])) {
         i <<- i - 1

--- a/R/req-perform-parallel.R
+++ b/R/req-perform-parallel.R
@@ -91,6 +91,8 @@ req_perform_parallel <- function(
   tryCatch(
     queue$process(),
     interrupt = function(cnd) {
+      check_repeated_interrupt()
+      
       queue$queue_status <- "errored"
       queue$process()
 

--- a/R/req-perform-sequential.R
+++ b/R/req-perform-sequential.R
@@ -92,6 +92,8 @@ req_perform_sequential <- function(
       }
     },
     interrupt = function(cnd) {
+      check_repeated_interrupt()
+
       resps <- resps[seq_len(i)]
       cli::cli_alert_warning(
         "Terminating iteration; returning {i} response{?s}."

--- a/R/utils.R
+++ b/R/utils.R
@@ -351,9 +351,9 @@ paste_c <- function(..., collapse = "") {
 # Give user the get-out-of-jail-free card if interrupt-capturing function
 # is wrapped inside a loop
 check_repeated_interrupt <- function() {
-  if (Sys.time() - the$last_interrupt < 1) {
+  if (as.double(Sys.time()) - the$last_interrupt < 1) {
     cli::cli_alert_warning("Interrupting")
     interrupt()
   }
-  the$last_interrupt <- Sys.time()
+  the$last_interrupt <- as.double(Sys.time())
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -347,3 +347,13 @@ log_stream <- function(..., prefix = "<< ") {
 paste_c <- function(..., collapse = "") {
   paste0(c(...), collapse = collapse)
 }
+
+# Give user the get-out-of-jail-free card if interrupt-capturing function
+# is wrapped inside a loop
+check_repeated_interrupt <- function() {
+  if (Sys.time() - the$last_interrupt < 1) {
+    cli::cli_alert_warning("Interrupting")
+    interrupt()
+  }
+  the$last_interrupt <- Sys.time()
+}


### PR DESCRIPTION
I can't see any way to test this, but I experimented interactively with this code:

```R
library(httr2)
request_base <- request(example_url())
reqs <- rep(list(request_base |> req_url_path("/delay/0.1")), 100)
repeat(req_perform_parallel(reqs))
```

Fixes #720