### PR TITLE
Unobfuscated `req_body_form()` and `req_body_json()` data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_body_json()` and `req_body_form()` correctly unobfuscated inputs, as documented (#754).
 * `req_perform_iterative()`, `req_perform_sequential()`, `req_perform_parallel()`, and `req_perform_promise()` now support mocking (#651).
 * `new_response()` is now exported (#751).
 * URL construction is now powered by `curl::curl_modify_url()`, and hence now (correctly) escapes the `path` component (#732). This means that `req_url_path()` now can only affect the path component of the URL, not the query params or fragment.

--- a/R/req-body.R
+++ b/R/req-body.R
@@ -240,7 +240,11 @@ req_get_body <- function(req) {
     raw = req$body$data,
     string = req$body$data,
     file = readBin(req$body$data, "raw", n = file.size(req$body$data)),
-    json = unclass(exec(jsonlite::toJSON, req$body$data, !!!req$body$params)),
+    json = unclass(exec(
+      jsonlite::toJSON,
+      unobfuscate(req$body$data),
+      !!!req$body$params
+    )),
     form = url_query_build(unobfuscate(req$body$data)),
     multipart = {
       # This is a bit clumsy because it requires a real request, which is

--- a/R/secret.R
+++ b/R/secret.R
@@ -230,7 +230,7 @@ print.httr2_obfuscated <- function(x, ...) {
 }
 
 unobfuscate <- function(x) {
-  if (inherits(x, "httr2_obfuscated")) {
+  if (is_obfuscated(x)) {
     secret_decrypt(x, obfuscate_key())
   } else if (is.list(x)) {
     x[] <- lapply(x, unobfuscate)
@@ -241,6 +241,9 @@ unobfuscate <- function(x) {
 }
 attr(unobfuscate, "srcref") <- "function(x) {}"
 
+is_obfuscated <- function(x) {
+  inherits(x, "httr2_obfuscated")
+}
 
 # Helpers -----------------------------------------------------------------
 

--- a/R/url.R
+++ b/R/url.R
@@ -354,6 +354,8 @@ format_query_param <- function(
 
   if (inherits(x, "AsIs")) {
     unclass(x)
+  } else if (is_obfuscated(x)) {
+    x
   } else {
     x <- format(x, scientific = FALSE, trim = TRUE, justify = "none")
     x <- curl::curl_escape(x)

--- a/tests/testthat/_snaps/req-body.md
+++ b/tests/testthat/_snaps/req-body.md
@@ -65,3 +65,18 @@
       2
       ---{id}
 
+# mutlipart data is unobufcated
+
+    Code
+      cat(req_get_body(req))
+    Output
+      ---{id}
+      Content-Disposition: form-data; name="x"
+      
+      x
+      ---{id}
+      Content-Disposition: form-data; name="y"
+      
+      y
+      ---{id}
+

--- a/tests/testthat/test-req-body.R
+++ b/tests/testthat/test-req-body.R
@@ -158,6 +158,12 @@ test_that("can't modify non-json data", {
   expect_snapshot(req |> req_body_json_modify(a = 1), error = TRUE)
 })
 
+test_that("json is unobufcated", {
+  req <- request_test() |>
+    req_body_json(list(x = "x", y = obfuscated("ZdYJeG8zwISodg0nu4UxBhs")))
+  expect_equal(req_get_body(req), '{"x":"x","y":"y"}')
+})
+
 # req_body_form() --------------------------------------------------------------
 
 test_that("can send named elements as form", {
@@ -183,6 +189,12 @@ test_that("can modify body data", {
 
   req3 <- req1 |> req_body_form(a = 3, a = 4)
   expect_equal(req3$body$data, list(a = I("3"), a = I("4")))
+})
+
+test_that("form data is unobufcated", {
+  req <- request_test() |>
+    req_body_form(x = "x", y = obfuscated("ZdYJeG8zwISodg0nu4UxBhs"))
+  expect_equal(req_get_body(req), 'x=x&y=y')
 })
 
 # req_body_multipart() ---------------------------------------------------------
@@ -228,4 +240,13 @@ test_that("no issues with partial name matching", {
     req_body_multipart(d = "some data")
 
   expect_named(req$body$data, "d")
+})
+
+test_that("mutlipart data is unobufcated", {
+  req <- request_test() |>
+    req_body_multipart(x = "x", y = obfuscated("ZdYJeG8zwISodg0nu4UxBhs"))
+  expect_snapshot(
+    cat(req_get_body(req)),
+    transform = function(x) gsub("--------.*", "---{id}", x)
+  )
 })


### PR DESCRIPTION
As documented in `obfuscate()`.

Fixes #754