### PR TITLE
`req_perform_parallel()` handles `progress` argument correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_perform_parallel()` handles `progress` argument consistently with other functions (#726).
 * `req_error()` errors with long bodies are now correctly wrapped (#727).
 * `req_perform_stream()` has been soft deprecated.
 * Deprecated functions `mutli_req_perform()`, `req_stream()`, `with_mock()` and `local_mock()` hav been removed. Deprecated arguments `req_perform_parallel(pool)` and `req_oauth_auth_code(host_name, host_ip, port)`/ `oauth_flow_auth_code(host_name, host_ip, port)` have been removed.

--- a/R/req-perform-iterative.R
+++ b/R/req-perform-iterative.R
@@ -129,11 +129,7 @@ req_perform_iterative <- function(
     }
   }
 
-  progress <- create_progress_bar(
-    total = max_reqs,
-    name = "Iterating",
-    config = progress
-  )
+  progress <- create_progress_bar(progress, max_reqs)
 
   resps <- vector("list", length = if (is.finite(max_reqs)) max_reqs else 100)
   i <- 1L

--- a/R/req-perform-parallel.R
+++ b/R/req-perform-parallel.R
@@ -81,6 +81,7 @@ req_perform_parallel <- function(
     mock = mock,
     frame = environment()
   )
+  queue$progress$update(set = 0)
 
   tryCatch(
     queue$process(),
@@ -96,6 +97,7 @@ req_perform_parallel <- function(
       )
     }
   )
+  queue$progress$done()
 
   if (on_error == "stop") {
     is_error <- map_lgl(queue$resps, is_error)

--- a/R/req-perform-parallel.R
+++ b/R/req-perform-parallel.R
@@ -81,7 +81,6 @@ req_perform_parallel <- function(
     mock = mock,
     frame = environment()
   )
-  queue$progress$update(set = 0)
 
   tryCatch(
     queue$process(),

--- a/R/req-perform-parallel.R
+++ b/R/req-perform-parallel.R
@@ -79,7 +79,7 @@ req_perform_parallel <- function(
     on_error = on_error,
     progress = progress,
     mock = mock,
-    error_call = environment()
+    frame = environment()
   )
 
   tryCatch(
@@ -146,21 +146,20 @@ RequestQueue <- R6::R6Class(
       on_error = "stop",
       progress = FALSE,
       mock = NULL,
-      error_call = caller_env()
+      frame = caller_env()
     ) {
       n <- length(reqs)
 
-      if (isTRUE(progress)) {
-        self$progress <- cli::cli_progress_bar(
-          total = n,
-          format = paste0(
-            "[{self$queue_status}] ",
-            "({self$n_pending} + {self$n_retries}) -> {self$n_active} -> {self$n_complete} | ",
-            "{cli::pb_bar} {cli::pb_percent}"
-          ),
-          .envir = error_call
-        )
-      }
+      self$progress <- create_progress_bar(
+        progress,
+        total = n,
+        format = paste0(
+          "[{self$queue_status}] ",
+          "({self$n_pending} + {self$n_retries}) -> {self$n_active} -> {self$n_complete} | ",
+          "{cli::pb_bar} {cli::pb_percent}"
+        ),
+        frame = frame
+      )
 
       # goal is for pool to not do any queueing; i.e. the curl pool will
       # only ever contain requests that we actually want to process. Any
@@ -188,7 +187,7 @@ RequestQueue <- R6::R6Class(
           on_failure = function(error) self$done_failure(i, error),
           on_error = function(error) self$done_error(i, error),
           mock = mock,
-          error_call = error_call
+          error_call = frame
         )
       })
       self$resps <- vector("list", n)
@@ -215,9 +214,7 @@ RequestQueue <- R6::R6Class(
         return(FALSE)
       }
 
-      if (!is.null(self$progress)) {
-        cli::cli_progress_update(id = self$progress, set = self$n_complete)
-      }
+      self$progress$update(set = self$n_complete)
 
       if (self$queue_status == "waiting") {
         request_deadline <- max(self$token_deadline, self$rate_limit_deadline)

--- a/R/req-perform-sequential.R
+++ b/R/req-perform-sequential.R
@@ -67,11 +67,7 @@ req_perform_sequential <- function(
   err_catch <- on_error != "stop"
   err_return <- on_error == "return"
 
-  progress <- create_progress_bar(
-    total = length(reqs),
-    name = "Iterating",
-    config = progress
-  )
+  progress <- create_progress_bar(progress, length(reqs))
 
   resps <- rep_along(reqs, list())
 


### PR DESCRIPTION
Once again handling `FALSE`, a string, or a list. Fixes #726

Hard to test progress bars, so I used this code interactively:

```R
base_req <- request(example_url("/delay/0.25")) |> req_throttle(capacity = 60, fill_time_s = 60)
reqs <- rep(list(base_req), 65)

. <- req_perform_parallel(reqs)
. <- req_perform_parallel(reqs, progress = FALSE)
. <- req_perform_parallel(reqs, progress = "name")
. <- req_perform_parallel(reqs, progress = list())
```

@fwimp this ended up being quite a bit more tricky than I had expected.