### PR TITLE
Drop empty/missing redacted headers

### DIFF
--- a/R/headers.R
+++ b/R/headers.R
@@ -108,6 +108,10 @@ str.httr2_headers <- function(object, ..., no.list = FALSE) {
 is_redacted <- function(x) {
   map_lgl(x, is_weakref)
 }
+is_redacted_empty <- function(x) {
+  map_lgl(x, \(x) is_weakref(x) && is.null(wref_value(x)))
+}
+
 which_redacted <- function(x) {
   names(x)[is_redacted(x)]
 }

--- a/R/req-headers.R
+++ b/R/req-headers.R
@@ -120,6 +120,8 @@ req_get_headers <- function(req, redacted = c("drop", "redact", "reveal")) {
   redacted <- arg_match(redacted)
 
   headers <- req$headers
+  headers <- headers[!is_redacted_empty(headers)]
+
   if (redacted == "drop") {
     headers <- headers[!is_redacted(headers)]
   } else if (redacted == "redact") {

--- a/tests/testthat/test-req-headers.R
+++ b/tests/testthat/test-req-headers.R
@@ -57,6 +57,16 @@ test_that("can control redaction", {
   expect_equal(req_get_headers(req, "reveal"), list(a = "1", b = "2"))
 })
 
+test_that("empty redacted headers are always dropped", {
+  req <- request("http://example.com")
+  req <- req_headers(req, a = 1L, b = 2L, .redact = "a")
+  req2 <- unserialize(serialize(req, NULL))
+
+  expect_equal(req_get_headers(req2, "drop"), list(b = "2"))
+  expect_equal(req_get_headers(req2, "redact"), list(b = "2"))
+  expect_equal(req_get_headers(req2, "reveal"), list(b = "2"))
+})
+
 # redaction ---------------------------------------------------------------
 
 test_that("can control which headers to redact", {


### PR DESCRIPTION
Otherwise it's a bit confusing when you look at a request that you've loaded.