### PR TITLE
Pass original URL to curl_modify_url() to keep original encoding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* Refactor `url_modify()` to better retain exact formatting of URL components 
+  that are not modified. (#788)
+
 # httr2 1.2.1
 
 * Colons in paths are no longer escaped.

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -127,6 +127,12 @@ test_that("path always starts with /", {
   expect_equal(url_modify("https://x.com/abc", path = NULL), "https://x.com/")
 })
 
+test_that("escaped slashes are retained", {
+  url <- "http://x.com/a%2Fb/"
+  expect_equal(url_modify(url), url)
+  expect_equal(url_modify(url, query = list(x=1)), "http://x.com/a%2Fb/?x=1")
+})
+
 # relative url ------------------------------------------------------------
 
 test_that("can set relative urls", {

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -127,7 +127,7 @@ test_that("path always starts with /", {
   expect_equal(url_modify("https://x.com/abc", path = NULL), "https://x.com/")
 })
 
-test_that("escaped slashes are retained", {
+test_that("only modifies specified components", {
   url <- "http://x.com/a%2Fb/"
   expect_equal(url_modify(url), url)
   expect_equal(url_modify(url, query = list(x=1)), "http://x.com/a%2Fb/?x=1")


### PR DESCRIPTION
This changes the logic of `modify_url()` to start with the original URL and modify it, rather than build it from scratch from the list of its components. 

This should prevent normalisation of components of the URL that we do not modify, in particular the escaped slash.

Fixes #786

