### PR TITLE
Make req_url_path_append() copy literal url encoding for original URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # httr2 (development version)
 
 * Refactor `url_modify()` to better retain exact formatting of URL components 
-  that are not modified. (#788)
+  that are not modified. (#788, #794)
 
 # httr2 1.2.1
 

--- a/R/req-url.R
+++ b/R/req-url.R
@@ -98,10 +98,10 @@ req_url_path_append <- function(req, ...) {
   check_request(req)
   path <- dots_to_path(...)
 
-  url <- url_parse(req$url)
-  url$path <- paste0(sub("/$", "", url$path), path)
-
-  req_url(req, url_build(url))
+  # Keep verbatim url-encoding of input path
+  input <- curl::curl_parse_url(req$url, decode = FALSE)$path
+  path <- paste0(sub("/$", "", input), path)
+  req_url(req, curl::curl_modify_url(req$url, path = I(path)))
 }
 
 #' Get request URL

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -133,6 +133,18 @@ test_that("only modifies specified components", {
   expect_equal(url_modify(url, query = list(x=1)), "http://x.com/a%2Fb/?x=1")
 })
 
+test_that("appending to path does not normalise encoding", {
+  req <- request("http://x.com/a%2Fb/")
+  expect_equal(
+    req_url_path_append(req, "foo/bar")$url,
+    "http://x.com/a%2Fb/foo/bar"
+  )
+  expect_equal(
+    req_url_path_append(req, "foo%2Fbar")$url,
+    "http://x.com/a%2Fb/foo%2Fbar"
+  )
+})
+
 # relative url ------------------------------------------------------------
 
 test_that("can set relative urls", {


### PR DESCRIPTION
In #788 we prevented normalisation of the url path when we modify other parts of the URL. 

Because `req_url_path_append()` actually changes the path itself, so it would still get normalised. Apparently this is also a problem sometimes. This PR changes the behavior of `req_url_path_append()` to append to the verbatim path, without any decoding/re-encoding.

Fixes #793