### PR TITLE
Add "Supported By Posit" badge to httr2 website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,117 +6,118 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="httr2.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
   mode: auto
 
 reference:
-  - title: Requests
-    subtitle: Create and modify
-    contents:
-      - request
-      - req_body
-      - req_cookie_preserve
-      - req_headers
-      - req_method
-      - req_options
-      - req_progress
-      - req_proxy
-      - req_template
-      - req_timeout
-      - req_url
-      - req_user_agent
+- title: Requests
+  subtitle: Create and modify
+  contents:
+  - request
+  - req_body
+  - req_cookie_preserve
+  - req_headers
+  - req_method
+  - req_options
+  - req_progress
+  - req_proxy
+  - req_template
+  - req_timeout
+  - req_url
+  - req_user_agent
 
-  - subtitle: Debugging/testing
-    contents:
-      - last_request
-      - req_dry_run
-      - req_verbose
-      - with_verbosity
+- subtitle: Debugging/testing
+  contents:
+  - last_request
+  - req_dry_run
+  - req_verbose
+  - with_verbosity
 
-  - subtitle: Authentication
-    contents:
-      - starts_with("req_auth")
-      - starts_with("req_oauth")
+- subtitle: Authentication
+  contents:
+  - starts_with("req_auth")
+  - starts_with("req_oauth")
 
-  - title: Perform a request
-    contents:
-      - req_perform
-      - req_perform_stream
-      - req_perform_connection
-      - req_perform_promise
+- title: Perform a request
+  contents:
+  - req_perform
+  - req_perform_stream
+  - req_perform_connection
+  - req_perform_promise
 
-  - subtitle: Control the process
-    desc: >
-      These functions don't modify the HTTP request that is sent to the server,
-      but affect the overall process of `req_perform()`.
-    contents:
-      - req_cache
-      - req_error
-      - req_throttle
-      - req_retry
+- subtitle: Control the process
+  desc: >
+    These functions don't modify the HTTP request that is sent to the server,
+    but affect the overall process of `req_perform()`.
+  contents:
+  - req_cache
+  - req_error
+  - req_throttle
+  - req_retry
 
-  - title: Perform multiple requests
-    contents:
-      - req_perform_iterative
-      - req_perform_parallel
-      - req_perform_sequential
-      - starts_with("iterate_")
-      - starts_with("resps_")
+- title: Perform multiple requests
+  contents:
+  - req_perform_iterative
+  - req_perform_parallel
+  - req_perform_sequential
+  - starts_with("iterate_")
+  - starts_with("resps_")
 
-  - title: Handle the response
-    contents:
-      - starts_with("resp_")
+- title: Handle the response
+  contents:
+  - starts_with("resp_")
 
-  - title: URL manipulation
-    contents:
-      - starts_with("url_")
+- title: URL manipulation
+  contents:
+  - starts_with("url_")
 
-  - title: Miscellaneous helpers
-    contents:
-      - curl_translate
-      - is_online
+- title: Miscellaneous helpers
+  contents:
+  - curl_translate
+  - is_online
 
-  - title: OAuth
-    desc: >
-      These functions implement the low-level components of OAuth.
-    contents:
-      - starts_with("oauth_")
-      - -starts_with("req_oauth")
+- title: OAuth
+  desc: >
+    These functions implement the low-level components of OAuth.
+  contents:
+  - starts_with("oauth_")
+  - -starts_with("req_oauth")
 
-  - title: Developer tooling
-    desc: >
-      These functions are useful when developing packges that use httr2.
-    
-  - subtitle: Keeping secrets
-    contents:
-      - obfuscate
-      - secrets
+- title: Developer tooling
+  desc: >
+    These functions are useful when developing packges that use httr2.
 
-  - subtitle: Testing
-    contents:
-      - response
+- subtitle: Keeping secrets
+  contents:
+  - obfuscate
+  - secrets
 
-  - subtitle: Introspection and mocking
-    contents:
-      - new_response
-      - starts_with("req_get_")
-      - StreamingBody
-      - with_mocked_responses
+- subtitle: Testing
+  contents:
+  - response
+
+- subtitle: Introspection and mocking
+  contents:
+  - new_response
+  - starts_with("req_get_")
+  - StreamingBody
+  - with_mocked_responses
 
 articles:
-  - title: Using httr2
-    navbar: ~
-    contents:
-      - articles/wrapping-apis
-      - articles/oauth
+- title: Using httr2
+  navbar:
+  contents:
+  - articles/wrapping-apis
+  - articles/oauth
 
 news:
   releases:
-    - text: httr2 1.2.0
-      href: https://www.tidyverse.org/blog/2025/07/httr2-1-2-0/
-    - text: httr2 1.1.0
-      href: https://www.tidyverse.org/blog/2025/01/httr2-1-1-0/
-    - text: "httr2 1.0.0"
-      href: https://www.tidyverse.org/blog/2023/11/httr2-1-0-0/
+  - text: httr2 1.2.0
+    href: https://www.tidyverse.org/blog/2025/07/httr2-1-2-0/
+  - text: httr2 1.1.0
+    href: https://www.tidyverse.org/blog/2025/01/httr2-1-1-0/
+  - text: "httr2 1.0.0"
+    href: https://www.tidyverse.org/blog/2023/11/httr2-1-0-0/


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the httr2 website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of httr2 website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/httr2-1200.png)

At 992px browser width:

![Screenshot of httr2 website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/httr2-992.png)

At 991px browser width:

![Screenshot of httr2 website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/httr2-991.png)

