### PR TITLE
Efficiency: promises method

### DIFF
--- a/R/req-promise.R
+++ b/R/req-promise.R
@@ -106,11 +106,11 @@ req_perform_promise <- function(
       mock = mock
     )
     pooled_req$submit(pool)
-    ensure_pool_poller(pool, reject)
+    ensure_pool_poller(pool)
   })
 }
 
-ensure_pool_poller <- function(pool, reject) {
+ensure_pool_poller <- function(pool) {
   monitor <- pool_poller_monitor(pool)
   if (monitor$already_going()) {
     return()


### PR DESCRIPTION
In our poller, we can replace a usage of `tryCatch()` with `withCallingHandlers()`, as we just need to enact a side-effect and let the error percolate up to a [tryCatch](https://github.com/rstudio/promises/blob/82cf56f9ef53411c3d82ef6186b8206847f7f0c1/R/promise.R#L387) already established within `promises::promise()` from where it's called.

There's always a benefit to avoiding tryCatch:

``` r
bench::mark(
  withCallingHandlers({}, error = identity),
  tryCatch({}, error = identity)
)
#> # A tibble: 2 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                       <bch:tm> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 withCallingHandlers({ }, error …    410ns   492ns  1572514.        0B    157. 
#> 2 tryCatch({ }, error = identity)    1.35µs   1.6µs   605433.        0B     60.5
```

<sup>Created on 2025-10-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>