### PR TITLE
docs(iterate-responses): Fixed a few small typos

### DIFF
--- a/R/iterate-responses.R
+++ b/R/iterate-responses.R
@@ -1,12 +1,12 @@
 #' Tools for working with lists of responses
 #'
 #' @description
-#' These function provide a basic toolkit for operating with lists of
+#' These functions provide a basic toolkit for operating with lists of
 #' responses and possibly errors, as returned by [req_perform_parallel()],
 #' [req_perform_sequential()] and [req_perform_iterative()].
 #'
-#' * `resps_successes()` returns a list successful responses.
-#' * `resps_failures()` returns a list failed responses (i.e. errors).
+#' * `resps_successes()` returns a list of successful responses.
+#' * `resps_failures()` returns a list of failed responses (i.e. errors).
 #' * `resps_requests()` returns the list of requests that corresponds to
 #'   each request.
 #' * `resps_data()` returns all the data in a single vector or data frame.

--- a/man/resps_successes.Rd
+++ b/man/resps_successes.Rd
@@ -26,12 +26,12 @@ output in \code{list()} to avoid combining all the bodies into a single raw
 vector, e.g. \verb{resps |> resps_data(\\(resp) list(resp_body_raw(resp)))}.}
 }
 \description{
-These function provide a basic toolkit for operating with lists of
+These functions provide a basic toolkit for operating with lists of
 responses and possibly errors, as returned by \code{\link[=req_perform_parallel]{req_perform_parallel()}},
 \code{\link[=req_perform_sequential]{req_perform_sequential()}} and \code{\link[=req_perform_iterative]{req_perform_iterative()}}.
 \itemize{
-\item \code{resps_successes()} returns a list successful responses.
-\item \code{resps_failures()} returns a list failed responses (i.e. errors).
+\item \code{resps_successes()} returns a list of successful responses.
+\item \code{resps_failures()} returns a list of failed responses (i.e. errors).
 \item \code{resps_requests()} returns the list of requests that corresponds to
 each request.
 \item \code{resps_data()} returns all the data in a single vector or data frame.


### PR DESCRIPTION
Fixed a few minor typos in help page for `resps_success()` (from iterate-responses.R),