### PR TITLE
patch to fix Azure OAuth Code flow when using default (localhost) redirect URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # httr2 (development version)
 
-* * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
-
+* `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
+
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
 

--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -183,7 +183,7 @@ oauth_flow_auth_code <- function(
     client,
     grant_type = "authorization_code",
     code = code,
-    redirect_uri = redirect_uri,
+    redirect_uri = redirect$uri,
     !!!token_params
   )
 }


### PR DESCRIPTION
fixes #828 

When `oauth_flow_auth_code` uses the default redirect URI from `oauth_redirect_uri()` (and it returns "http://localhost/"), the subsequent call to `normalize_redirect_uri()` adds a random port, creating a mismatch between the authorization and token requests.

possible solution: use `redirect$uri` in the second request as well.

