### PR TITLE
Fix synchronization in streaming tests

### DIFF
--- a/R/req-verbose.R
+++ b/R/req-verbose.R
@@ -127,6 +127,7 @@ req_verbose_test <- function(req) {
 transform_verbose_response <- function(lines) {
   lines <- gsub(example_url(), "<webfakes>/", lines, fixed = TRUE)
   lines <- lines[!grepl("^<- (Date|ETag|Content-Length):", lines)]
-  lines <- lines[!grepl("\\*  Closing connection", lines)]
+  # Connection-lifecycle notes appear non-deterministically depending on timing
+  lines <- lines[!grepl("\\*  (Closing|shutting down) connection", lines)]
   lines
 }

--- a/tests/testthat/helper-sync.R
+++ b/tests/testthat/helper-sync.R
@@ -14,19 +14,13 @@ sync_req <- function(name, .env = parent.frame()) {
   nanonext::pipe_notify(sock, cv, add = TRUE)
   nanonext::listen(sock, url = sprintf("ipc:///tmp/nanonext%s", name))
 
-  function(
-    expr = {},
-    timeout = 1000L
-  ) {
+  function(resp, timeout = 1000L) {
     if (!connected) {
       nanonext::until(cv, timeout)
       connected <<- TRUE
     }
-    ctx <- nanonext::context(sock)
-    saio <- nanonext::send_aio(ctx, 0L, mode = 2L)
-    expr
-    nanonext::call_aio(nanonext::recv_aio(ctx, mode = 8L, timeout = timeout))
-    nanonext::msleep(50L) # wait, as nanonext messages can return faster than side effects (e.g. stream)
+    nanonext::send(sock, 0L, mode = 2L, block = timeout)
+    wait_for_http_data(resp, timeout / 1000)
   }
 }
 
@@ -44,17 +38,71 @@ sync_rep <- function(name, .env = parent.frame()) {
   nanonext::pipe_notify(sock, cv, add = TRUE)
   nanonext::dial(sock, url = sprintf("ipc:///tmp/nanonext%s", name))
 
-  function(
-    expr = {},
-    timeout = 1000L
-  ) {
+  function(expr = {}, timeout = 1000L) {
     if (!connected) {
       nanonext::until(cv, timeout)
       connected <<- TRUE
     }
-    ctx <- nanonext::context(sock)
-    nanonext::call_aio(nanonext::recv_aio(ctx, mode = 8L, timeout = timeout))
+    nanonext::recv(sock, mode = 8L, block = timeout)
     expr
-    nanonext::send(ctx, 0L, mode = 2L, block = TRUE)
+  }
+}
+
+# Blocks (by polling the connection) until the next chunk of body data has
+# arrived, or the stream is complete, so that a subsequent non-blocking
+# resp_stream_lines()/resp_stream_sse() read can see it. Used both for the
+# initial chunk a server sends before any sync() signal and for the chunks a
+# sync() signal releases.
+wait_for_http_data <- function(resp, timeout_s = 5) {
+  if (resp$body$is_complete()) {
+    return(invisible(TRUE))
+  }
+
+  deadline <- as.double(Sys.time()) + timeout_s
+  poll_interval <- 0.01
+
+  while (as.double(Sys.time()) < deadline) {
+    chunk <- resp$body$read(256)
+    if (length(chunk) > 0) {
+      resp$cache$push_back <- c(resp$cache$push_back, chunk)
+      return(invisible(TRUE))
+    }
+
+    if (resp$body$is_complete()) {
+      return(invisible(TRUE))
+    }
+
+    remaining <- deadline - as.double(Sys.time())
+    if (remaining > 0) {
+      Sys.sleep(poll_interval)
+    }
+  }
+
+  invisible(FALSE)
+}
+
+# Blocks (by polling the connection) until the stream is complete, i.e. the
+# server has closed the connection. A sync() signal only guarantees the last
+# chunk's *data* has arrived; the EOF that marks completion can lag behind it.
+# Use this before a final read that depends on completion, such as flushing a
+# trailing line that has no terminator.
+wait_for_complete <- function(resp, timeout_s = 5) {
+  deadline <- as.double(Sys.time()) + timeout_s
+
+  repeat {
+    chunk <- resp$body$read(256)
+    if (length(chunk) > 0) {
+      resp$cache$push_back <- c(resp$cache$push_back, chunk)
+    }
+
+    if (resp$body$is_complete()) {
+      return(invisible(TRUE))
+    }
+
+    if (as.double(Sys.time()) >= deadline) {
+      return(invisible(FALSE))
+    }
+
+    Sys.sleep(0.01)
   }
 }

--- a/tests/testthat/test-resp-stream.R
+++ b/tests/testthat/test-resp-stream.R
@@ -75,6 +75,7 @@ test_that("can join lines across multiple reads", {
 
   resp1 <- req_perform_connection(req, blocking = FALSE)
   withr::defer(close(resp1))
+  wait_for_http_data(resp1)
 
   out <- resp_stream_lines(resp1)
   expect_equal(out, character())
@@ -83,7 +84,7 @@ test_that("can join lines across multiple reads", {
   out <- resp_stream_lines(resp1)
   expect_equal(out, character())
 
-  sync()
+  sync(resp1)
   out <- resp_stream_lines(resp1)
   expect_equal(out, "This is a complete sentence.")
 })
@@ -107,6 +108,7 @@ test_that("handles line endings of multiple kinds", {
 
   resp1 <- req_perform_connection(req, blocking = FALSE)
   withr::defer(close(resp1))
+  wait_for_http_data(resp1)
 
   expected_values <- list(
     "\u3042",
@@ -121,8 +123,9 @@ test_that("handles line endings of multiple kinds", {
 
   for (expected in expected_values) {
     rlang::inject(expect_equal(resp_stream_lines(resp1), !!expected))
-    sync()
+    sync(resp1)
   }
+  wait_for_complete(resp1)
   expect_warning(out <- resp_stream_lines(resp1), "incomplete final line")
   expect_equal(out, "eof without line ending")
   expect_equal(resp_stream_lines(resp1), character(0))
@@ -173,6 +176,7 @@ test_that("streams the specified number of lines", {
 
   resp2 <- req_perform_connection(req, blocking = FALSE)
   withr::defer(close(resp2))
+  wait_for_http_data(resp2)
   expect_equal(resp_stream_lines(resp2, 3), c("a", "b", "c"))
   expect_equal(resp_stream_lines(resp2, 3), c("d", "e"))
   expect_equal(resp_stream_lines(resp2, 3), character())
@@ -228,16 +232,17 @@ test_that("can join sse events across multiple reads", {
   # Non-blocking returns NULL until data is ready
   resp1 <- req_perform_connection(req, blocking = FALSE)
   withr::defer(close(resp1))
+  wait_for_http_data(resp1)
 
   out <- resp_stream_sse(resp1)
   expect_equal(out, NULL)
   expect_equal(resp1$cache$push_back, charToRaw("data: 1\n"))
 
-  sync()
+  sync(resp1)
   out <- resp_stream_sse(resp1)
   expect_equal(out, NULL)
 
-  sync()
+  sync(resp1)
   out <- resp_stream_sse(resp1)
   expect_equal(out, list(type = "message", data = "1\n2", id = ""))
   expect_equal(resp1$cache$push_back, charToRaw("data: 3\n\n"))
@@ -268,6 +273,7 @@ test_that("sse always interprets data as UTF-8", {
   # Non-blocking returns NULL until data is ready
   resp1 <- req_perform_connection(req, blocking = FALSE)
   withr::defer(close(resp1))
+  wait_for_http_data(resp1)
 
   out <- resp_stream_sse(resp1)
 
@@ -287,6 +293,7 @@ test_that("streaming size limits enforced", {
 
   resp1 <- req_perform_connection(req, blocking = FALSE)
   withr::defer(close(resp1))
+  wait_for_http_data(resp1)
   expect_error(
     out <- resp_stream_sse(resp1, max_size = 999),
     class = "httr2_streaming_error"


### PR DESCRIPTION
Follow up to #703 in addressing #683.

The streaming tests coordinate a separate webfakes server with the client over nanonext, but those messages outrun the HTTP data: a message confirms a chunk was *sent*, not that it *arrived* or that the stream *closed*. #703's fixed 50ms delay mostly masked this but still flaked on CI (usually macOS/Windows).

The tests now wait for the actual state instead of a timer:

- `wait_for_http_data()` — until the next chunk has arrived
- `wait_for_complete()` — until the connection has closed, before reads that need the stream finished

The nanonext message just triggers the next chunk.
Also drops curl's non-deterministic `shutting down connection` line from the `verbosity = 3` snapshot.
