### PR TITLE
Move check_installed call for httpuv inside localhost block

### DIFF
--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -193,14 +193,14 @@ normalize_redirect_uri <- function(redirect_uri, error_call = caller_env()) {
   localhost <- parsed$hostname %in% c("localhost", "127.0.0.1")
 
   if (localhost) {
-    check_installed("httpuv", "for desktop OAuth", call = NULL)
     if (is_hosted_session()) {
       cli::cli_abort(
         "Can't use localhost {.arg redirect_uri} in a hosted environment.",
         call = error_call
       )
     }
-
+    
+    check_installed("httpuv", "for desktop OAuth", call = NULL)
     if (is.null(parsed$port)) {
       parsed$port <- httpuv::randomPort()
     }


### PR DESCRIPTION
I think one can move the `check_install` after. No need to install package `httpuv` if the session is hosted.