### PR TITLE
req_body_form() sets req to an empty list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
+* `req_body_form()` now creates a valid empty request body when no parameters
+  are provided (@arcresu, #836).
 
 # httr2 1.2.2
 

--- a/R/req-body.R
+++ b/R/req-body.R
@@ -156,7 +156,7 @@ req_body_form <- function(
   check_request(.req)
 
   dots <- multi_dots(..., .multi = .multi)
-  data <- modify_list(.req$body$data, !!!dots)
+  data <- modify_list(.req$body$data %||% list(), !!!dots)
   req_body(.req, data = data, type = "form")
 }
 

--- a/tests/testthat/test-req-body.R
+++ b/tests/testthat/test-req-body.R
@@ -197,6 +197,13 @@ test_that("form data is unobufcated", {
   expect_equal(rawToChar(req$options$postfields), 'x=x&y=y')
 })
 
+test_that("empty form data gives a valid request", {
+  req <- request_test() |>
+    req_body_form() |>
+    req_body_apply()
+  expect_equal(req$body$data, list())
+})
+
 # req_body_multipart() ---------------------------------------------------------
 
 test_that("can send named elements as multipart", {


### PR DESCRIPTION
Ensures that when `req$body$data` is `NULL`, an empty list is used instead. Note that this is exactly what is done already a few lines above for `req_body_json_modify()` which is conceptually doing the same thing.

Fixes #835.