### PR TITLE
Let `oauth_client()` carry its server endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # httr2 (development version)
 
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
+* `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#591).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # httr2 (development version)
 
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
-* `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#591).
+* `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#846).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).

--- a/R/oauth-client.R
+++ b/R/oauth-client.R
@@ -1,13 +1,15 @@
 #' Create an OAuth client
 #'
-#' An OAuth app is the combination of a client, a set of endpoints
-#' (i.e. urls where various requests should be sent), and an authentication
-#' mechanism. A client consists of at least a `client_id`, and also often
-#' a `client_secret`. You'll get these values when you create the client on
-#' the API's website.
+#' An OAuth client is the combination of a set of credentials (at least a
+#' `client_id`, and often a `client_secret` or `key`), the server endpoints it
+#' talks to, and an authentication mechanism. You'll get the credentials when
+#' you register the client on the API's website. Supply the `token_url`
+#' directly, or pass the result of [oauth_server_metadata()] as `metadata` to
+#' fill in all of the server's endpoints at once.
 #'
 #' @param id Client identifier.
-#' @param token_url Url to retrieve an access token.
+#' @param token_url Url to retrieve an access token. Not needed if `metadata`
+#'   is supplied, which sets it from the `token_endpoint`.
 #' @param secret Client secret. For most apps, this is technically confidential
 #'   so in principle you should avoid storing it in source code. However, many
 #'   APIs require it in order to provide a user friendly authentication
@@ -35,20 +37,40 @@
 #'   directory. If `NULL`, generated from hash of `client_id`. If you're
 #'   defining a client for use in a package, I recommend that you use
 #'   the package name.
+#' @param metadata An [oauth_server_metadata()] object. When supplied, the
+#'   client's server endpoints are taken from the discovery document, so the
+#'   OAuth flows can find them without you passing each one. An explicit
+#'   `token_url` still wins over `metadata`.
 #' @return An OAuth client: An S3 list with class `httr2_oauth_client`.
 #' @export
 #' @examples
 #' oauth_client("myclient", "http://example.com/token_url", secret = "DONTLOOK")
 oauth_client <- function(
   id,
-  token_url,
+  token_url = NULL,
   secret = NULL,
   key = NULL,
   auth = c("body", "header", "jwt_sig"),
   auth_params = list(),
-  name = hash(id)
+  name = hash(id),
+  metadata = NULL
 ) {
   check_string(id)
+
+  auth_url <- NULL
+  device_auth_url <- NULL
+  if (!is.null(metadata)) {
+    oauth_metadata_check(metadata)
+    token_url <- token_url %||% metadata$token_endpoint
+    auth_url <- metadata$authorization_endpoint
+    device_auth_url <- metadata$device_authorization_endpoint
+  }
+
+  if (is.null(token_url)) {
+    cli::cli_abort(
+      "Must supply {.arg token_url}, or {.arg metadata} that advertises a {.field token_endpoint}."
+    )
+  }
   check_string(token_url)
   check_string(secret, allow_null = TRUE)
 
@@ -83,6 +105,8 @@ oauth_client <- function(
       secret = secret,
       key = key,
       token_url = token_url,
+      auth_url = auth_url,
+      device_auth_url = device_auth_url,
       auth = auth,
       auth_params = auth_params
     ),
@@ -207,6 +231,20 @@ oauth_client_req_auth_jwt_sig <- function(
 }
 
 # Helpers -----------------------------------------------------------------
+
+oauth_flow_url <- function(url, client, field, call = caller_env()) {
+  url <- url %||% client[[field]]
+  if (is.null(url)) {
+    cli::cli_abort(
+      c(
+        "Must supply {.arg auth_url}.",
+        i = "Either pass it directly or set it on the {.arg client}, e.g. with {.fn oauth_server_metadata}."
+      ),
+      call = call
+    )
+  }
+  url
+}
 
 oauth_flow_check <- function(
   flow,

--- a/R/oauth-flow-auth-code.R
+++ b/R/oauth-flow-auth-code.R
@@ -43,7 +43,8 @@
 #' @inheritParams req_perform
 #' @param client An [oauth_client()].
 #' @param auth_url Authorization url; you'll need to discover this by reading
-#'   the documentation.
+#'   the documentation. Not needed if `metadata` was supplied to
+#'   [oauth_client()], which sets it from the `authorization_endpoint`.
 #' @param scope Scopes to be requested from the resource owner.
 #' @param pkce Use "Proof Key for Code Exchange"? This adds an extra layer of
 #'   security and should always be used if supported by the server.
@@ -98,7 +99,7 @@
 req_oauth_auth_code <- function(
   req,
   client,
-  auth_url,
+  auth_url = NULL,
   scope = NULL,
   pkce = TRUE,
   auth_params = list(),
@@ -107,6 +108,7 @@ req_oauth_auth_code <- function(
   cache_disk = FALSE,
   cache_key = NULL
 ) {
+  auth_url <- oauth_flow_url(auth_url, client, "auth_url")
   redirect <- normalize_redirect_uri(redirect_uri = redirect_uri)
 
   params <- list(
@@ -127,7 +129,7 @@ req_oauth_auth_code <- function(
 #' @rdname req_oauth_auth_code
 oauth_flow_auth_code <- function(
   client,
-  auth_url,
+  auth_url = NULL,
   scope = NULL,
   pkce = TRUE,
   auth_params = list(),
@@ -135,6 +137,7 @@ oauth_flow_auth_code <- function(
   redirect_uri = oauth_redirect_uri()
 ) {
   oauth_flow_check("authorization code", client, interactive = TRUE)
+  auth_url <- oauth_flow_url(auth_url, client, "auth_url")
 
   redirect <- normalize_redirect_uri(redirect_uri = redirect_uri)
 
@@ -199,7 +202,7 @@ normalize_redirect_uri <- function(redirect_uri, error_call = caller_env()) {
         call = error_call
       )
     }
-    
+
     check_installed("httpuv", "for desktop OAuth", call = NULL)
     if (is.null(parsed$port)) {
       parsed$port <- httpuv::randomPort()

--- a/R/oauth-flow-device.R
+++ b/R/oauth-flow-device.R
@@ -15,6 +15,9 @@
 #'   the URL is printed to the console and the user must open it themselves.
 #' @inheritParams oauth_flow_password
 #' @inheritParams req_oauth_auth_code
+#' @param auth_url Device authorization url; you'll need to discover this by
+#'   reading the documentation. Not needed if `metadata` was supplied to
+#'   [oauth_client()], which sets it from the `device_authorization_endpoint`.
 #' @returns `req_oauth_device()` returns a modified HTTP [request] that will
 #'   use OAuth; `oauth_flow_device()` returns an [oauth_token].
 #' @examples
@@ -31,7 +34,7 @@
 req_oauth_device <- function(
   req,
   client,
-  auth_url,
+  auth_url = NULL,
   scope = NULL,
   open_browser = is_interactive(),
   auth_params = list(),
@@ -39,6 +42,7 @@ req_oauth_device <- function(
   cache_disk = FALSE,
   cache_key = NULL
 ) {
+  auth_url <- oauth_flow_url(auth_url, client, "device_auth_url")
   params <- list(
     client = client,
     auth_url = auth_url,
@@ -55,7 +59,7 @@ req_oauth_device <- function(
 #' @rdname req_oauth_device
 oauth_flow_device <- function(
   client,
-  auth_url,
+  auth_url = NULL,
   pkce = FALSE,
   scope = NULL,
   open_browser = is_interactive(),
@@ -63,6 +67,7 @@ oauth_flow_device <- function(
   token_params = list()
 ) {
   oauth_flow_check("device", client, interactive = open_browser)
+  auth_url <- oauth_flow_url(auth_url, client, "device_auth_url")
 
   if (pkce) {
     code <- oauth_flow_auth_code_pkce()

--- a/R/oauth-server-metadata.R
+++ b/R/oauth-server-metadata.R
@@ -3,14 +3,17 @@
 #' @description
 #' `oauth_server_metadata()` fetches and parses an OAuth 2.0 Authorization
 #' Server Metadata document (`r rfc(8414)`) or OpenID Connect Discovery
-#' document, returning the endpoints advertised by an issuer. Use it to
-#' discover values like `authorization_endpoint`, `token_endpoint`, and
-#' `device_authorization_endpoint` rather than hard-coding them:
+#' document, returning the endpoints advertised by an issuer.
+#'
+#' Use it to discover values like `authorization_endpoint`, `token_endpoint`,
+#' and `device_authorization_endpoint` rather than hard-coding them. Pass the
+#' result to [oauth_client()] as `metadata` and the endpoints are wired up for
+#' you:
 #'
 #' ```r
-#' meta <- oauth_server_metadata("https://accounts.google.com")
-#' client <- oauth_client("id", token_url = meta$token_endpoint, secret = "...")
-#' oauth_flow_auth_code(client, auth_url = meta$authorization_endpoint)
+#' metadata <- oauth_server_metadata("https://accounts.google.com")
+#' client <- oauth_client("id", metadata = metadata, secret = "...")
+#' token <- oauth_flow_auth_code(client)
 #' ```
 #'
 #' As a security measure, the `issuer` reported in the returned document is
@@ -85,6 +88,15 @@ oauth_metadata_url <- function(issuer, type) {
     oauth = paste0("/.well-known/oauth-authorization-server", path)
   )
   url_build(parsed)
+}
+
+oauth_metadata_check <- function(metadata, call = caller_env()) {
+  if (!inherits(metadata, "httr2_oauth_server_metadata")) {
+    cli::cli_abort(
+      "{.arg metadata} must be created with {.fn oauth_server_metadata}.",
+      call = call
+    )
+  }
 }
 
 #' @export

--- a/man/oauth_client.Rd
+++ b/man/oauth_client.Rd
@@ -6,18 +6,20 @@
 \usage{
 oauth_client(
   id,
-  token_url,
+  token_url = NULL,
   secret = NULL,
   key = NULL,
   auth = c("body", "header", "jwt_sig"),
   auth_params = list(),
-  name = hash(id)
+  name = hash(id),
+  metadata = NULL
 )
 }
 \arguments{
 \item{id}{Client identifier.}
 
-\item{token_url}{Url to retrieve an access token.}
+\item{token_url}{Url to retrieve an access token. Not needed if \code{metadata}
+is supplied, which sets it from the \code{token_endpoint}.}
 
 \item{secret}{Client secret. For most apps, this is technically confidential
 so in principle you should avoid storing it in source code. However, many
@@ -50,16 +52,22 @@ by \code{auth}.}
 directory. If \code{NULL}, generated from hash of \code{client_id}. If you're
 defining a client for use in a package, I recommend that you use
 the package name.}
+
+\item{metadata}{An \code{\link[=oauth_server_metadata]{oauth_server_metadata()}} object. When supplied, the
+client's server endpoints are taken from the discovery document, so the
+OAuth flows can find them without you passing each one. An explicit
+\code{token_url} still wins over \code{metadata}.}
 }
 \value{
 An OAuth client: An S3 list with class \code{httr2_oauth_client}.
 }
 \description{
-An OAuth app is the combination of a client, a set of endpoints
-(i.e. urls where various requests should be sent), and an authentication
-mechanism. A client consists of at least a \code{client_id}, and also often
-a \code{client_secret}. You'll get these values when you create the client on
-the API's website.
+An OAuth client is the combination of a set of credentials (at least a
+\code{client_id}, and often a \code{client_secret} or \code{key}), the server endpoints it
+talks to, and an authentication mechanism. You'll get the credentials when
+you register the client on the API's website. Supply the \code{token_url}
+directly, or pass the result of \code{\link[=oauth_server_metadata]{oauth_server_metadata()}} as \code{metadata} to
+fill in all of the server's endpoints at once.
 }
 \examples{
 oauth_client("myclient", "http://example.com/token_url", secret = "DONTLOOK")

--- a/man/oauth_server_metadata.Rd
+++ b/man/oauth_server_metadata.Rd
@@ -33,13 +33,16 @@ advertise are simply absent.
 \description{
 \code{oauth_server_metadata()} fetches and parses an OAuth 2.0 Authorization
 Server Metadata document (\href{https://datatracker.ietf.org/doc/html/rfc8414}{RFC 8414}) or OpenID Connect Discovery
-document, returning the endpoints advertised by an issuer. Use it to
-discover values like \code{authorization_endpoint}, \code{token_endpoint}, and
-\code{device_authorization_endpoint} rather than hard-coding them:
+document, returning the endpoints advertised by an issuer.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{meta <- oauth_server_metadata("https://accounts.google.com")
-client <- oauth_client("id", token_url = meta$token_endpoint, secret = "...")
-oauth_flow_auth_code(client, auth_url = meta$authorization_endpoint)
+Use it to discover values like \code{authorization_endpoint}, \code{token_endpoint},
+and \code{device_authorization_endpoint} rather than hard-coding them. Pass the
+result to \code{\link[=oauth_client]{oauth_client()}} as \code{metadata} and the endpoints are wired up for
+you:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{metadata <- oauth_server_metadata("https://accounts.google.com")
+client <- oauth_client("id", metadata = metadata, secret = "...")
+token <- oauth_flow_auth_code(client)
 }\if{html}{\out{</div>}}
 
 As a security measure, the \code{issuer} reported in the returned document is

--- a/man/req_oauth_auth_code.Rd
+++ b/man/req_oauth_auth_code.Rd
@@ -8,7 +8,7 @@
 req_oauth_auth_code(
   req,
   client,
-  auth_url,
+  auth_url = NULL,
   scope = NULL,
   pkce = TRUE,
   auth_params = list(),
@@ -20,7 +20,7 @@ req_oauth_auth_code(
 
 oauth_flow_auth_code(
   client,
-  auth_url,
+  auth_url = NULL,
   scope = NULL,
   pkce = TRUE,
   auth_params = list(),
@@ -34,7 +34,8 @@ oauth_flow_auth_code(
 \item{client}{An \code{\link[=oauth_client]{oauth_client()}}.}
 
 \item{auth_url}{Authorization url; you'll need to discover this by reading
-the documentation.}
+the documentation. Not needed if \code{metadata} was supplied to
+\code{\link[=oauth_client]{oauth_client()}}, which sets it from the \code{authorization_endpoint}.}
 
 \item{scope}{Scopes to be requested from the resource owner.}
 

--- a/man/req_oauth_device.Rd
+++ b/man/req_oauth_device.Rd
@@ -8,7 +8,7 @@
 req_oauth_device(
   req,
   client,
-  auth_url,
+  auth_url = NULL,
   scope = NULL,
   open_browser = is_interactive(),
   auth_params = list(),
@@ -19,7 +19,7 @@ req_oauth_device(
 
 oauth_flow_device(
   client,
-  auth_url,
+  auth_url = NULL,
   pkce = FALSE,
   scope = NULL,
   open_browser = is_interactive(),
@@ -32,8 +32,9 @@ oauth_flow_device(
 
 \item{client}{An \code{\link[=oauth_client]{oauth_client()}}.}
 
-\item{auth_url}{Authorization url; you'll need to discover this by reading
-the documentation.}
+\item{auth_url}{Device authorization url; you'll need to discover this by
+reading the documentation. Not needed if \code{metadata} was supplied to
+\code{\link[=oauth_client]{oauth_client()}}, which sets it from the \code{device_authorization_endpoint}.}
 
 \item{scope}{Scopes to be requested from the resource owner.}
 

--- a/tests/testthat/_snaps/oauth-client.md
+++ b/tests/testthat/_snaps/oauth-client.md
@@ -70,3 +70,21 @@
       * token_url: "http://example.com"
       * auth     : <function>
 
+# metadata is validated and token_url must be resolvable
+
+    Code
+      oauth_client("id")
+    Condition
+      Error in `oauth_client()`:
+      ! Must supply `token_url`, or `metadata` that advertises a token_endpoint.
+    Code
+      oauth_client("id", metadata = metadata)
+    Condition
+      Error in `oauth_client()`:
+      ! Must supply `token_url`, or `metadata` that advertises a token_endpoint.
+    Code
+      oauth_client("id", token_url = "https://x.com", metadata = list())
+    Condition
+      Error in `oauth_client()`:
+      ! `metadata` must be created with `oauth_server_metadata()`.
+

--- a/tests/testthat/_snaps/oauth-flow-auth-code.md
+++ b/tests/testthat/_snaps/oauth-flow-auth-code.md
@@ -1,3 +1,12 @@
+# errors when no auth_url is available
+
+    Code
+      req_oauth_auth_code(request("https://example.com"), client)
+    Condition
+      Error in `req_oauth_auth_code()`:
+      ! Must supply `auth_url`.
+      i Either pass it directly or set it on the `client`, e.g. with `oauth_server_metadata()`.
+
 # desktop style can't run in hosted environment
 
     Code

--- a/tests/testthat/test-oauth-client.R
+++ b/tests/testthat/test-oauth-client.R
@@ -28,6 +28,43 @@ test_that("client has useful print method", {
   })
 })
 
+test_that("metadata fills endpoints, explicit values win", {
+  metadata <- structure(
+    list(
+      token_endpoint = "https://example.com/token",
+      authorization_endpoint = "https://example.com/auth",
+      device_authorization_endpoint = "https://example.com/device"
+    ),
+    class = "httr2_oauth_server_metadata"
+  )
+
+  client <- oauth_client("id", metadata = metadata)
+  expect_equal(client$token_url, "https://example.com/token")
+  expect_equal(client$auth_url, "https://example.com/auth")
+  expect_equal(client$device_auth_url, "https://example.com/device")
+
+  client <- oauth_client(
+    "id",
+    token_url = "https://other.com/token",
+    metadata = metadata
+  )
+  expect_equal(client$token_url, "https://other.com/token")
+  expect_equal(client$auth_url, "https://example.com/auth")
+  expect_equal(client$device_auth_url, "https://example.com/device")
+})
+
+test_that("metadata is validated and token_url must be resolvable", {
+  metadata <- structure(
+    list(authorization_endpoint = "https://example.com/auth"),
+    class = "httr2_oauth_server_metadata"
+  )
+  expect_snapshot(error = TRUE, {
+    oauth_client("id")
+    oauth_client("id", metadata = metadata)
+    oauth_client("id", token_url = "https://x.com", metadata = list())
+  })
+})
+
 test_that("picks default auth", {
   expect_equal(
     oauth_client("x", "url", key = NULL)$auth,

--- a/tests/testthat/test-oauth-flow-auth-code.R
+++ b/tests/testthat/test-oauth-flow-auth-code.R
@@ -1,3 +1,38 @@
+test_that("auth_url falls back to the client, explicit wins", {
+  metadata <- structure(
+    list(
+      token_endpoint = "https://example.com/token",
+      authorization_endpoint = "https://example.com/auth"
+    ),
+    class = "httr2_oauth_server_metadata"
+  )
+  client <- oauth_client("id", metadata = metadata)
+
+  req <- req_oauth_auth_code(request("https://example.com"), client)
+  expect_equal(
+    req$policies$auth_sign$params$flow_params$auth_url,
+    "https://example.com/auth"
+  )
+
+  req <- req_oauth_auth_code(
+    request("https://example.com"),
+    client,
+    auth_url = "https://other.com/auth"
+  )
+  expect_equal(
+    req$policies$auth_sign$params$flow_params$auth_url,
+    "https://other.com/auth"
+  )
+})
+
+test_that("errors when no auth_url is available", {
+  client <- oauth_client("id", token_url = "https://example.com/token")
+  expect_snapshot(
+    req_oauth_auth_code(request("https://example.com"), client),
+    error = TRUE
+  )
+})
+
 test_that("desktop style can't run in hosted environment", {
   client <- oauth_client("abc", "http://example.com")
 

--- a/tests/testthat/test-oauth-flow-device.R
+++ b/tests/testthat/test-oauth-flow-device.R
@@ -24,3 +24,11 @@ test_that("auth_url falls back to the client's device_auth_url, explicit wins", 
     "https://other.com/device"
   )
 })
+
+test_that("oauth_flow_device() resolves auth_url from the client", {
+  client <- oauth_client("id", token_url = "https://example.com/token")
+  expect_error(
+    oauth_flow_device(client, open_browser = FALSE),
+    "Must supply"
+  )
+})

--- a/tests/testthat/test-oauth-flow-device.R
+++ b/tests/testthat/test-oauth-flow-device.R
@@ -1,0 +1,26 @@
+test_that("auth_url falls back to the client's device_auth_url, explicit wins", {
+  metadata <- structure(
+    list(
+      token_endpoint = "https://example.com/token",
+      device_authorization_endpoint = "https://example.com/device"
+    ),
+    class = "httr2_oauth_server_metadata"
+  )
+  client <- oauth_client("id", metadata = metadata)
+
+  req <- req_oauth_device(request("https://example.com"), client)
+  expect_equal(
+    req$policies$auth_sign$params$flow_params$auth_url,
+    "https://example.com/device"
+  )
+
+  req <- req_oauth_device(
+    request("https://example.com"),
+    client,
+    auth_url = "https://other.com/device"
+  )
+  expect_equal(
+    req$policies$auth_sign$params$flow_params$auth_url,
+    "https://other.com/device"
+  )
+})

--- a/vignettes/articles/oauth.Rmd
+++ b/vignettes/articles/oauth.Rmd
@@ -70,7 +70,10 @@ The two you'll almost always need are the authorization URL, where the user logs
 Some providers also offer a device authorization URL, used by the device flow.
 
 Traditionally you had to dig these URLs out of the provider's documentation, but many providers now publish them in a standard discovery document (defined by [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) and OpenID Connect Discovery).
-`oauth_server_metadata()` fetches and parses that document, so you can look up every endpoint from a single issuer URL:
+`oauth_server_metadata()` fetches and parses that document, so you can look up every endpoint from a single **issuer URL**.
+
+You still need to find the issuer URL in the provider's documentation, but that's the only value you need.
+For example, GitHub's issuer is `https://github.com/login/oauth` and Google's is `https://accounts.google.com`.
 
 ```{r}
 #| eval: false

--- a/vignettes/articles/oauth.Rmd
+++ b/vignettes/articles/oauth.Rmd
@@ -2,7 +2,8 @@
 title: "OAuth"
 ---
 
-```{r, include = FALSE}
+```{r}
+#| include: false
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -71,7 +72,8 @@ Some providers also offer a device authorization URL, used by the device flow.
 Traditionally you had to dig these URLs out of the provider's documentation, but many providers now publish them in a standard discovery document (defined by [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) and OpenID Connect Discovery).
 `oauth_server_metadata()` fetches and parses that document, so you can look up every endpoint from a single issuer URL:
 
-```{r, eval = FALSE}
+```{r}
+#| eval: false
 metadata <- oauth_server_metadata("https://github.com/login/oauth")
 metadata
 #> <httr2_oauth_server_metadata>
@@ -98,7 +100,8 @@ This process varies from API to API (it's normal to spend some time hunting thro
 Sometimes the client id is all you need, and you can create a httr2 client with `oauth_client()`.
 Pair it with the `metadata` you discovered above and httr2 fills in the endpoints for you:
 
-```{r, eval = FALSE}
+```{r}
+#| eval: false
 client <- oauth_client(
   id = "28acfec0674bb3da9f38",
   metadata = metadata,
@@ -111,7 +114,8 @@ I have a bunch of apps that I've used for testing, so here I've used the name `h
 
 > **Specifying endpoints by hand.** If your provider doesn't publish discovery metadata, supply the `token_url` directly instead of `metadata`:
 >
-> ```{r, eval = FALSE}
+> ```{r}
+> #| eval: false
 > client <- oauth_client(
 >   id = "28acfec0674bb3da9f38",
 >   token_url = "https://github.com/login/oauth/access_token",
@@ -141,7 +145,8 @@ obfuscate("secret")
 
 Here's what a complete client specification for GitHub looks like, using a real app that I created specifically for this vignette:
 
-```{r, eval = FALSE}
+```{r}
+#| eval: false
 client <- oauth_client(
   id = "28acfec0674bb3da9f38",
   secret = obfuscated("J9iiGmyelHltyxqrHXW41ZZPZamyUNxSX1_uKnvPeinhhxET_7FfUs2X0LLKotXY2bpgOMoHRCo"),
@@ -156,7 +161,8 @@ You can certainly uncover my client secret if you are an experienced R programme
 
 I recommend wrapping client creation in a function in your package, e.g.:
 
-```{r, eval = FALSE}
+```{r}
+#| eval: false
 github_client <- function() {
   metadata <- oauth_server_metadata("https://github.com/login/oauth")
   oauth_client(
@@ -196,13 +202,15 @@ These two steps are described in the following sections.
 `oauth_flow_auth_code()` is the best way to verify you've correctly specified the parameters to the client, without depending on correctly understanding any other part of the API.
 Because the client was built from `metadata`, it already knows the authorization URL, so you can get a token to access the GitHub API (using the client defined above) with just:
 
-```{r, eval = FALSE}
+```{r}
+#| eval: false
 token <- oauth_flow_auth_code(client)
 ```
 
 > **Specifying the authorization URL by hand.** If you built the client without `metadata`, pass `auth_url` directly:
 >
-> ```{r, eval = FALSE}
+> ```{r}
+> #| eval: false
 > token <- oauth_flow_auth_code(
 >   client = client,
 >   auth_url = "https://github.com/login/oauth/authorize"
@@ -315,7 +323,8 @@ Currently, httr2 supports the following flows:
 
     > **Specifying the device URL by hand.** The device flow needs a separate device authorization URL, which `metadata` doesn't always include (GitHub, for instance, omits it). Pass it to `req_oauth_device()` as `auth_url`:
     >
-    > ```{r, eval = FALSE}
+    > ```{r}
+    > #| eval: false
     > req |>
     >   req_oauth_device(
     >     client = github_client(),

--- a/vignettes/articles/oauth.Rmd
+++ b/vignettes/articles/oauth.Rmd
@@ -62,9 +62,32 @@ Overall this leads to a hierarchy of credentials from weakest to strongest:
 
 Now that you've got the basic idea of OAuth, lets talk about the details.
 
+## Server metadata
+
+Most OAuth providers expose a handful of **endpoints**: URLs where httr2 sends the various OAuth requests.
+The two you'll almost always need are the authorization URL, where the user logs in and grants access, and the token URL, where httr2 exchanges that grant for an access token.
+Some providers also offer a device authorization URL, used by the device flow.
+
+Traditionally you had to dig these URLs out of the provider's documentation, but many providers now publish them in a standard discovery document (defined by [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) and OpenID Connect Discovery).
+`oauth_server_metadata()` fetches and parses that document, so you can look up every endpoint from a single issuer URL:
+
+```{r, eval = FALSE}
+metadata <- oauth_server_metadata("https://github.com/login/oauth")
+metadata
+#> <httr2_oauth_server_metadata>
+#> * issuer                : "https://github.com/login/oauth"
+#> * jwks_uri              : "https://github.com/login/oauth/.well-known/jwks"
+#> * authorization_endpoint: "https://github.com/login/oauth/authorize"
+#> * token_endpoint        : "https://github.com/login/oauth/access_token"
+#> * and 6 more fields.
+```
+
+You'll hand this `metadata` to `oauth_client()` and to the flow functions, and httr2 picks out the endpoint each one needs.
+Discovery isn't universal though: if your provider doesn't publish a metadata document, you can specify the URLs by hand instead, as we'll show in this vignette.
+
 ## Clients
 
-The first step in working with any OAuth API is to create an **application** **client**.
+After discovering the server's endpoints, you'll first need to create an **application** **client**.
 It's called an application client because in the wider world OAuth is usually used with a web, phone, or tv app, but here your "app" is going to be your R package.
 For this reason, httr2 calls the application client a **client**, but many APIs will call it an OAuth application.
 
@@ -72,20 +95,31 @@ To create a client, you'll need to first register for a developer account on the
 In most cases this is easy, totally automated, and only takes a couple of minutes.
 That will give you access to some sort of developer portal which you can then use to register a new OAuth app (aka a client).
 This process varies from API to API (it's normal to spend some time hunting through the docs and settings), but at the end of it you'll get a client id (another random string of numbers and letters).
-Sometimes the client id is all you need, and you can create a httr2 client with `oauth_client()`, e.g.:
+Sometimes the client id is all you need, and you can create a httr2 client with `oauth_client()`.
+Pair it with the `metadata` you discovered above and httr2 fills in the endpoints for you:
 
-```{r}
+```{r, eval = FALSE}
 client <- oauth_client(
   id = "28acfec0674bb3da9f38",
-  token_url = "https://github.com/login/oauth/access_token",
+  metadata = metadata,
   name = "hadley-oauth-test-2"
 )
 ```
 
-The call to `oauth_client()` also includes a `name` and a `token_url`.
+The `name` is human-facing, and should typically be the same as your package (the thing that prompted you to create the client).
+I have a bunch of apps that I've used for testing, so here I've used the name `hadley-oauth-test-2` to remind me which app this client corresponds to.
 
--   The `name` is human-facing, and should typically be the same as your package (the thing that prompted you to create the client). I have a bunch of apps that I've used for testing, so here I've used the name `hadley-oauth-test-2` to remind me which app this client corresponds to.
--   The `token_url` points to the URL that's used to obtain an access token. You'll need to find this from the documentation for the API you're wrapping; it will typically be found in the section that describes the OAuth process and will be an endpoint that returns an access token. Don't be surprised if this endpoint feels very different to the rest of the API; auth is often implemented by a third-party package with slightly different conventions to the rest of the API.
+> **Specifying endpoints by hand.** If your provider doesn't publish discovery metadata, supply the `token_url` directly instead of `metadata`:
+>
+> ```{r, eval = FALSE}
+> client <- oauth_client(
+>   id = "28acfec0674bb3da9f38",
+>   token_url = "https://github.com/login/oauth/access_token",
+>   name = "hadley-oauth-test-2"
+> )
+> ```
+>
+> The `token_url` points to the URL that's used to obtain an access token. You'll need to find this from the documentation for the API you're wrapping; it will typically be found in the section that describes the OAuth process and will be an endpoint that returns an access token. Don't be surprised if this endpoint feels very different to the rest of the API; auth is often implemented by a third-party package with slightly different conventions to the rest of the API.
 
 ### Client secret
 
@@ -107,11 +141,11 @@ obfuscate("secret")
 
 Here's what a complete client specification for GitHub looks like, using a real app that I created specifically for this vignette:
 
-```{r}
+```{r, eval = FALSE}
 client <- oauth_client(
   id = "28acfec0674bb3da9f38",
   secret = obfuscated("J9iiGmyelHltyxqrHXW41ZZPZamyUNxSX1_uKnvPeinhhxET_7FfUs2X0LLKotXY2bpgOMoHRCo"),
-  token_url = "https://github.com/login/oauth/access_token",
+  metadata = metadata,
   name = "hadley-oauth-test"
 )
 ```
@@ -122,12 +156,13 @@ You can certainly uncover my client secret if you are an experienced R programme
 
 I recommend wrapping client creation in a function in your package, e.g.:
 
-```{r}
+```{r, eval = FALSE}
 github_client <- function() {
+  metadata <- oauth_server_metadata("https://github.com/login/oauth")
   oauth_client(
     id = "28acfec0674bb3da9f38",
     secret = obfuscated("J9iiGmyelHltyxqrHXW41ZZPZamyUNxSX1_uKnvPeinhhxET_7FfUs2X0LLKotXY2bpgOMoHRCo"),
-    token_url = "https://github.com/login/oauth/access_token",
+    metadata = metadata,
     name = "hadley-oauth-test"
   )
 }
@@ -158,15 +193,21 @@ These two steps are described in the following sections.
 
 ### Creating a token
 
-`oauth_flow_auth_code()` is the best way to verify you've correctly specified the parameters to the client and the `auth_url`, without depending on correctly understanding any other part of the API.
-For example, you could get a token to access the GitHub API (using the client defined above) with this code:
+`oauth_flow_auth_code()` is the best way to verify you've correctly specified the parameters to the client, without depending on correctly understanding any other part of the API.
+Because the client was built from `metadata`, it already knows the authorization URL, so you can get a token to access the GitHub API (using the client defined above) with just:
 
 ```{r, eval = FALSE}
-token <- oauth_flow_auth_code(
-  client = client,
-  auth_url = "https://github.com/login/oauth/authorize"
-)
+token <- oauth_flow_auth_code(client)
 ```
+
+> **Specifying the authorization URL by hand.** If you built the client without `metadata`, pass `auth_url` directly:
+>
+> ```{r, eval = FALSE}
+> token <- oauth_flow_auth_code(
+>   client = client,
+>   auth_url = "https://github.com/login/oauth/authorize"
+> )
+> ```
 
 This flow can't be used inside a vignette because it's designed specifically for interactive use, but if you do run it and print out the `token`, you'll see something like this:
 
@@ -184,7 +225,7 @@ There's not much to see here because httr2 automatically redacts the access toke
 If your call to `oauth_flow_auth_code()` succeeds then you've got everything set up correctly and you can proceed to the next step.
 Otherwise, you'll get an HTTP error.
 If you're very lucky, that error will be informative and will help you figure out want went wrong.
-However, in most cases, you'll need to carefully double check that you've correctly copied and pasted the client id and secret, and check that you've supplied the correct authorization and token urls (`auth_url` and `token_url`).
+However, in most cases, you'll need to carefully double check that you've correctly copied and pasted the client id and secret, and check that you discovered the right endpoints (or, if you supplied `auth_url` and `token_url` by hand, that they're correct).
 If the docs have multiple candidates for each and you're unclear about which is which, you'll need to do some systematic experimentation.
 
 ### Authenticating a request
@@ -204,15 +245,12 @@ req |>
   req_perform()
 ```
 
-We can authenticate this request with `req_oauth_auth_code()`, using the same arguments as our previous call to `oauth_flow_auth_code()`:
+We can authenticate this request with `req_oauth_auth_code()`, passing the client (which carries its endpoints from `metadata`):
 
 ```{r}
 #| eval: false
 req |>
-  req_oauth_auth_code(
-    client = github_client(),
-    auth_url = "https://github.com/login/oauth/authorize"
-  ) |>
+  req_oauth_auth_code(client = github_client()) |>
   req_perform() |>
   resp_body_json() |>
   str()
@@ -269,10 +307,21 @@ Each client gets its own subdirectory named using the client `name`, so if you t
 
 When wrapping an API, you'll need to carefully read the documentation to figure out which flows it provides.
 If possible you'll want to use the authorization code flow since it generally provides the best experience, but if it's not available you'll need to carefully consider the others.
+All of these flows reuse the same `client`, so once you've built it from `metadata` they pick up the `token_url` automatically.
 Currently, httr2 supports the following flows:
 
 -   `req_oauth_device()` uses the "device" flow which is designed for devices like TVs that don't have an easy way to enter data.
     It also works well from the console.
+
+    > **Specifying the device URL by hand.** The device flow needs a separate device authorization URL, which `metadata` doesn't always include (GitHub, for instance, omits it). Pass it to `req_oauth_device()` as `auth_url`:
+    >
+    > ```{r, eval = FALSE}
+    > req |>
+    >   req_oauth_device(
+    >     client = github_client(),
+    >     auth_url = "https://github.com/login/device/code"
+    >   )
+    > ```
 
 -   `req_oauth_client_credentials()` and `req_oauth_bearer_jwt()` are often needed for **service accounts**, accounts that represent automated services, not people, and are often used in non-interactive environments.
 


### PR DESCRIPTION
Closes #591.

Builds on `oauth_server_metadata()` (#845), which returns a provider's discovered endpoints. This PR makes use of this more ergonomic by not requiring you to hand-thread those endpoints into both `oauth_client(token_url = ...)` **and** each flow's `auth_url = ...`.

### Changes

`oauth_client()` gains a single `metadata` argument. Pass the result of `oauth_server_metadata()` and the client holds all of the server's endpoints, so the flows source them automatically:

```r
metadata <- oauth_server_metadata("https://accounts.google.com")
client   <- oauth_client("id", metadata = metadata, secret = "...")
token    <- oauth_flow_auth_code(client)   # auth_url comes from the client
```

The OAuth vignette is updated to primarily use this new method.

### Design considerations

- Merge endpoints onto the client, over passing `metadata` to each flow. The client already carries `token_url` — itself a server-owned endpoint — so it was already a partial merge + matches `oauth_client()`'s own documented definition of a client (credentials + endpoints + auth mechanism).

- Store translated endpoint strings, not the raw document (client gets `token_url`, `auth_url`, `device_auth_url` resolved from the metadata fields)

- Backward compatible. `token_url` stays (now optional, defaulting from `metadata$token_endpoint`); the flows' `auth_url` becomes optional, falling back to the client, with an explicit value always winning. Existing positional calls are unaffected.

- Validation. A `metadata` object is validated whenever supplied — even alongside an explicit `token_url` — so a wrong-class object fails at the call site rather than several frames deeper.