### PR TITLE
forward `token_params` on token refresh

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # httr2 (development version)
 
-* OAuth token refresh now forwards the `scope` and `token_params` from the original flow, so servers that vary token contents by scope issue an equivalent token on refresh rather than a narrower one.
+* OAuth token refresh now forwards `token_params` from the original flow, so extra token-endpoint parameters (e.g. a `scope` required on the token exchange) are sent on refresh as well as on the initial token request.
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* OAuth token refresh now forwards the `scope` and `token_params` from the original flow, so servers that vary token contents by scope issue an equivalent token on refresh rather than a narrower one.
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -50,7 +50,15 @@ auth_oauth_token_get <- function(cache, flow, flow_params = list()) {
       token <- exec(flow, !!!flow_params)
     } else {
       token <- tryCatch(
-        token_refresh(flow_params$client, token$refresh_token),
+        token_refresh(
+          flow_params$client,
+          token$refresh_token,
+          # Forward the scope and token params from the original flow so that
+          # servers which key token contents off scope (rather than the
+          # originally granted scope) issue an equivalent token on refresh.
+          scope = flow_params$scope,
+          token_params = flow_params$token_params %||% list()
+        ),
         httr2_oauth = function(cnd) {
           # If refresh fails, try to auth from scratch
           exec(flow, !!!flow_params)

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -53,7 +53,6 @@ auth_oauth_token_get <- function(cache, flow, flow_params = list()) {
         token_refresh(
           flow_params$client,
           token$refresh_token,
-          scope = flow_params$scope,
           token_params = flow_params$token_params %||% list()
         ),
         httr2_oauth = function(cnd) {

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -53,9 +53,6 @@ auth_oauth_token_get <- function(cache, flow, flow_params = list()) {
         token_refresh(
           flow_params$client,
           token$refresh_token,
-          # Forward the scope and token params from the original flow so that
-          # servers which key token contents off scope (rather than the
-          # originally granted scope) issue an equivalent token on refresh.
           scope = flow_params$scope,
           token_params = flow_params$token_params %||% list()
         ),

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -55,19 +55,14 @@ test_that("can refresh to get new token", {
   expect_equal(cache$get(), new_token)
 })
 
-test_that("refresh forwards scope and token_params from the flow", {
+test_that("refresh forwards token_params from the flow", {
   client <- oauth_client("test", "http://example.org/test")
   cache <- cache_mem(client)
   cache$set(oauth_token("123", refresh_token = "456", expires_in = -60))
 
   local_mocked_bindings(
-    token_refresh = function(
-      client,
-      refresh_token,
-      scope = NULL,
-      token_params = list()
-    ) {
-      oauth_token("789", scope = scope, token_params = token_params)
+    token_refresh = function(client, refresh_token, token_params = list()) {
+      oauth_token("789", token_params = token_params)
     }
   )
 
@@ -80,7 +75,6 @@ test_that("refresh forwards scope and token_params from the flow", {
       token_params = list(resource = "example")
     )
   )
-  expect_equal(token$scope, "read")
   expect_equal(token$token_params, list(resource = "example"))
 })
 

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -55,6 +55,35 @@ test_that("can refresh to get new token", {
   expect_equal(cache$get(), new_token)
 })
 
+test_that("refresh forwards scope and token_params from the flow", {
+  client <- oauth_client("test", "http://example.org/test")
+  cache <- cache_mem(client)
+  cache$set(oauth_token("123", refresh_token = "456", expires_in = -60))
+
+  local_mocked_bindings(
+    token_refresh = function(
+      client,
+      refresh_token,
+      scope = NULL,
+      token_params = list()
+    ) {
+      oauth_token("789", scope = scope, token_params = token_params)
+    }
+  )
+
+  token <- auth_oauth_token_get(
+    cache,
+    function(...) NULL,
+    flow_params = list(
+      client = client,
+      scope = "read",
+      token_params = list(resource = "example")
+    )
+  )
+  expect_equal(token$scope, "read")
+  expect_equal(token$token_params, list(resource = "example"))
+})
+
 test_that("can reflow if refresh fails", {
   client <- oauth_client("test", "http://example.org/test")
   cache <- cache_mem(client)


### PR DESCRIPTION
In service of https://github.com/tidyverse/ellmer/pull/1024.

With these changes, when a token refresh is needed, the OAuth flow will be retriggered when the token expires. Without them, users would see this after an hour:

```
Error in `req_perform_connection()` at ellmer/R/httr2.R:55:5:
! HTTP 401 Unauthorized.
ℹ Unauthorized: Invalid or expired token
```

...with no (exported) helper to reset the token.