### PR TITLE
Don't format long string query params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
+* `req_body_form()` and `req_url_query()` no longer error with "C stack usage is too close to the limit" when given very long string values (#805).
 * `req_body_form()` now creates a valid empty request body when no parameters
   are provided (@arcresu, #836).
 

--- a/R/url.R
+++ b/R/url.R
@@ -364,7 +364,9 @@ format_query_param <- function(
   } else if (is_obfuscated(x)) {
     x
   } else {
-    x <- format(x, scientific = FALSE, trim = TRUE, justify = "none")
+    if (!is.character(x)) {
+      x <- format(x, scientific = FALSE, trim = TRUE, justify = "none")
+    }
     x <- curl::curl_escape(x)
     if (form) {
       x <- gsub("%20", "+", x, fixed = TRUE)

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -266,6 +266,11 @@ test_that("formats numbers nicely", {
   expect_equal(format_query_param(1e9, "x"), "1000000000")
 })
 
+test_that("doesn't format long strings (#805)", {
+  big <- strrep("a", 16e6)
+  expect_equal(format_query_param(big, "x"), big)
+})
+
 test_that("can opt out of escaping", {
   expect_equal(format_query_param(I(","), "x"), ",")
 })


### PR DESCRIPTION
Base R's `format()` overflows the C stack on very long character strings. It was was only needed to suppress scientific notation for numeric params, so we now skip it when the value is already a string.

Fixes #805