### PR TITLE
Apply `req_error()` to cached responses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 e.g., `application/problem+json` (@cgiachalis, #782).
 * `req_body_form()` now creates a valid empty request body when no parameters
   are provided (@arcresu, #836).
+* `req_error()` is now applied to responses retrieved from the cache, so a custom `is_error` callback is respected on cache hits (@m-muecke, #806).
 
 # httr2 1.2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 e.g., `application/problem+json` (@cgiachalis, #782).
 * `req_body_form()` now creates a valid empty request body when no parameters
   are provided (@arcresu, #836).
-* `req_error()` is now applied to responses retrieved from the cache, so a custom `is_error` callback is respected on cache hits (@m-muecke, #806).
+* `req_error()` is now applied to responses retrieved from the cache, so a custom `is_error` callback is respected on cache hits (#806).
 
 # httr2 1.2.2
 

--- a/R/req-perform.R
+++ b/R/req-perform.R
@@ -87,10 +87,11 @@ req_perform <- function(
 
   req <- req_verbosity(req, verbosity)
 
-  req <- cache_pre_fetch(req, path)
-  if (is_response(req)) {
-    return(req)
+  fetched <- cache_pre_fetch(req, path)
+  if (is_response(fetched)) {
+    return(handle_resp(req, fetched, error_call = error_call))
   }
+  req <- fetched
 
   req_prep <- req_prepare(req)
   handle <- req_handle(req_prep)

--- a/tests/testthat/_snaps/req-cache.md
+++ b/tests/testthat/_snaps/req-cache.md
@@ -1,3 +1,11 @@
+# applies req_error() to responses from cache (#806)
+
+    Code
+      req_perform(req)
+    Condition
+      Error in `req_perform()`:
+      ! HTTP 200 OK.
+
 # cache emits useful debugging info
 
     Code

--- a/tests/testthat/_snaps/req-cache.md
+++ b/tests/testthat/_snaps/req-cache.md
@@ -1,11 +1,3 @@
-# applies req_error() to responses from cache (#806)
-
-    Code
-      req_perform(req)
-    Condition
-      Error in `req_perform()`:
-      ! HTTP 200 OK.
-
 # cache emits useful debugging info
 
     Code

--- a/tests/testthat/test-req-cache.R
+++ b/tests/testthat/test-req-cache.R
@@ -56,6 +56,20 @@ test_that("cached cache header added to request", {
   expect_equal(req3$headers$`If-None-Match`, '"abc"')
 })
 
+test_that("applies req_error() to responses from cache (#806)", {
+  req <- request("http://example.com") |>
+    req_cache(tempfile()) |>
+    req_error(is_error = \(resp) TRUE)
+  resp <- response(
+    200,
+    headers = "Expires: Wed, 01 Jan 3000 00:00:00 GMT",
+    body = charToRaw("abc")
+  )
+  cache_set(req, resp)
+
+  expect_snapshot(req_perform(req), error = TRUE)
+})
+
 test_that("error can use cached value", {
   req <- request("http://example.com") |> req_cache(tempfile())
   resp <- response(200, body = charToRaw("OK"))

--- a/tests/testthat/test-req-cache.R
+++ b/tests/testthat/test-req-cache.R
@@ -67,7 +67,7 @@ test_that("applies req_error() to responses from cache (#806)", {
   )
   cache_set(req, resp)
 
-  expect_snapshot(req_perform(req), error = TRUE)
+  expect_error(req_perform(req), class = "httr2_http_200")
 })
 
 test_that("error can use cached value", {


### PR DESCRIPTION
On a cache hit, `cache_pre_fetch()` returned the response directly, bypassing handle_resp() and its error check. Route cache-hit responses through `handle_resp()` so a custom is_error callback is respected.

Fixes #806