### PR TITLE
Add `pkce` argument to `req_oauth_device()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httr2 (development version)
 
+* `req_oauth_device()` gains a `pkce` argument to enable Proof Key for Code Exchange, matching `oauth_flow_device()` (#834).
 * OAuth token refresh now forwards `token_params` from the original flow, so extra token-endpoint parameters (e.g. a `scope` required on the token exchange) are sent on refresh as well as on the initial token request.
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
 * `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#846).

--- a/R/oauth-flow-device.R
+++ b/R/oauth-flow-device.R
@@ -35,6 +35,7 @@ req_oauth_device <- function(
   req,
   client,
   auth_url = NULL,
+  pkce = FALSE,
   scope = NULL,
   open_browser = is_interactive(),
   auth_params = list(),
@@ -46,6 +47,7 @@ req_oauth_device <- function(
   params <- list(
     client = client,
     auth_url = auth_url,
+    pkce = pkce,
     scope = scope,
     open_browser = open_browser,
     auth_params = auth_params,

--- a/man/req_oauth_device.Rd
+++ b/man/req_oauth_device.Rd
@@ -9,6 +9,7 @@ req_oauth_device(
   req,
   client,
   auth_url = NULL,
+  pkce = FALSE,
   scope = NULL,
   open_browser = is_interactive(),
   auth_params = list(),
@@ -36,6 +37,9 @@ oauth_flow_device(
 reading the documentation. Not needed if \code{metadata} was supplied to
 \code{\link[=oauth_client]{oauth_client()}}, which sets it from the \code{device_authorization_endpoint}.}
 
+\item{pkce}{Use "Proof Key for Code Exchange"? This adds an extra layer of
+security and should always be used if supported by the server.}
+
 \item{scope}{Scopes to be requested from the resource owner.}
 
 \item{open_browser}{If \code{TRUE} (the default in interactive sessions), the
@@ -56,9 +60,6 @@ Learn more in \url{https://httr2.r-lib.org/articles/oauth.html}.}
 
 \item{cache_key}{If you want to cache multiple tokens per app, use this
 key to disambiguate them.}
-
-\item{pkce}{Use "Proof Key for Code Exchange"? This adds an extra layer of
-security and should always be used if supported by the server.}
 }
 \value{
 \code{req_oauth_device()} returns a modified HTTP \link{request} that will

--- a/tests/testthat/test-oauth-flow-device.R
+++ b/tests/testthat/test-oauth-flow-device.R
@@ -25,6 +25,18 @@ test_that("auth_url falls back to the client's device_auth_url, explicit wins", 
   )
 })
 
+test_that("req_oauth_device() passes pkce through to the flow", {
+  client <- oauth_client("id", token_url = "https://example.com/token")
+
+  req <- req_oauth_device(
+    request("https://example.com"),
+    client,
+    auth_url = "https://example.com/device",
+    pkce = TRUE
+  )
+  expect_equal(req$policies$auth_sign$params$flow_params$pkce, TRUE)
+})
+
 test_that("oauth_flow_device() resolves auth_url from the client", {
   client <- oauth_client("id", token_url = "https://example.com/token")
   expect_error(


### PR DESCRIPTION
Exposes the PKCE support that `oauth_flow_device()` already had, so it can be enabled through the request wrapper too

Fixes #834.