### PR TITLE
Tolerate trailing comma in `Link` headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
 * `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#846).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
+* `iterate_with_link_url()` and `resp_link_url()` no longer error on `Link` headers that contain a trailing comma (#804).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
 * `req_body_form()` now creates a valid empty request body when no parameters

--- a/R/parse.R
+++ b/R/parse.R
@@ -22,6 +22,7 @@ parse_www_authenticate <- function(x) {
 
 parse_link <- function(x) {
   links <- parse_delim(x, ",")
+  links <- links[links != ""]
 
   parse_one <- function(x) {
     pieces <- parse_delim(x, ";")

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -49,6 +49,15 @@ test_that("can parse links", {
   )
 })
 
+test_that("parse_link() tolerates a trailing comma", {
+  header <- '<https://example.com/1>; rel="next",'
+
+  expect_equal(
+    parse_link(header),
+    list(list(url = "https://example.com/1", rel = "next"))
+  )
+})
+
 # Helpers -----------------------------------------------------------------
 
 test_that("parse_in_half handles common cases", {


### PR DESCRIPTION
Some servers (e.g. the Brazilian Chamber of Deputies API) emit `Link` headers with a trailing comma, which produced an empty entry that made `parse_link()` fail with "subscript out of bounds". Drop empty entries so `resp_link_url()` and `iterate_with_link_url()` keep working.

Fixes #804