### PR TITLE
Reuse `claim` for jwt_sig client auth in bearer JWT flow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
 * `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#846).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
+* `req_oauth_bearer_jwt()` now reuses its `claim` when the `client` also authenticates with `auth = "jwt_sig"`, so you no longer need to supply the claim twice. As a result, `oauth_client(auth = "jwt_sig")` no longer requires a `claim` in `auth_params` at creation time (#825).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
 * `req_body_form()` now creates a valid empty request body when no parameters

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * New `oauth_server_metadata()` discovers an OAuth/OpenID Connect issuer's endpoints from its `.well-known` metadata document (#845).
 * `oauth_client()` gains a `metadata` argument: pass the result of `oauth_server_metadata()` and the client carries all of the server's endpoints, so the OAuth flows pick them up automatically instead of threading them into each call (#846).
 * `oauth_flow_auth_code()` now correctly uses the same redirect URI for both authorization and token requests when using the default localhost redirect URL (@pedrobtz, #829).
-* `req_oauth_bearer_jwt()` now reuses its `claim` when the `client` also authenticates with `auth = "jwt_sig"`, so you no longer need to supply the claim twice. As a result, `oauth_client(auth = "jwt_sig")` no longer requires a `claim` in `auth_params` at creation time (#825).
+* `req_oauth_bearer_jwt()` now uses its `claim` as the basis for a separate client assertion when the `client` also authenticates with `auth = "jwt_sig"`, so you no longer need to supply the claim twice. As a result, `oauth_client(auth = "jwt_sig")` no longer requires a `claim` in `auth_params` at creation time (#825).
 * `last_response_json()` now works with content-types that end with `+json`, 
 e.g., `application/problem+json` (@cgiachalis, #782).
 * `req_body_form()` now creates a valid empty request body when no parameters

--- a/R/jwt.R
+++ b/R/jwt.R
@@ -71,3 +71,21 @@ jwt_encode_hmac <- function(claim, secret, size = 256, header = list()) {
   check_installed("jose")
   jose::jwt_encode_hmac(claim, secret, size = size, header = header)
 }
+
+# Resolve the various ways of specifying a claim (a list of arguments to
+# `jwt_claim()`, a zero-argument callback, or an already-built claim set) into
+# a single `jwt_claim` object.
+as_jwt_claim <- function(claim, error_call = caller_env()) {
+  if (inherits(claim, "jwt_claim")) {
+    claim
+  } else if (is_list(claim)) {
+    exec("jwt_claim", !!!claim)
+  } else if (is.function(claim)) {
+    claim()
+  } else {
+    cli::cli_abort(
+      "{.arg claim} must be a list or function.",
+      call = error_call
+    )
+  }
+}

--- a/R/jwt.R
+++ b/R/jwt.R
@@ -89,3 +89,12 @@ as_jwt_claim <- function(claim, error_call = caller_env()) {
     )
   }
 }
+
+as_jwt_client_claim <- function(claim, client_id, error_call = caller_env()) {
+  claim <- as_jwt_claim(claim, error_call = error_call)
+  claim <- unclass(claim)
+  claim$sub <- client_id
+  claim$jti <- NULL
+
+  exec("jwt_claim", !!!claim)
+}

--- a/R/oauth-client.R
+++ b/R/oauth-client.R
@@ -86,11 +86,6 @@ oauth_client <- function(
       if (is.null(key)) {
         cli::cli_abort("{.code auth = 'jwt_sig'} requires a {.arg key}.")
       }
-      if (!has_name(auth_params, "claim")) {
-        cli::cli_abort(
-          "{.code auth = 'jwt_sig'} requires a claim specification in {.arg auth_params}."
-        )
-      }
     }
 
     auth <- paste0("oauth_client_req_auth_", auth)
@@ -215,11 +210,16 @@ oauth_client_req_auth_body <- function(req, client) {
 oauth_client_req_auth_jwt_sig <- function(
   req,
   client,
-  claim,
+  claim = NULL,
   size = 256,
   header = list()
 ) {
-  claim <- exec("jwt_claim", !!!claim)
+  if (is.null(claim)) {
+    cli::cli_abort(
+      "{.code auth = 'jwt_sig'} requires a {.arg claim} in {.arg auth_params}."
+    )
+  }
+  claim <- as_jwt_claim(claim)
   jwt <- jwt_encode_sig(claim, key = client$key, size = size, header = header)
 
   # https://datatracker.ietf.org/doc/html/rfc7523#section-2.2

--- a/R/oauth-flow-jwt.R
+++ b/R/oauth-flow-jwt.R
@@ -18,6 +18,10 @@
 #'   [jwt_claim()] will automatically fill in the dynamic components.
 #'   If other components need to vary, you can instead provide a zero-argument
 #'   callback function which should call `jwt_claim()`.
+#'
+#'   If `client` authenticates itself with `auth = "jwt_sig"`, this `claim` is
+#'   reused for the client assertion unless the client supplies its own `claim`
+#'   in `auth_params`.
 #' @param signature Function use to sign `claim`, e.g. [jwt_encode_sig()].
 #' @param signature_params Additional arguments passed to `signature`, e.g.
 #'   `size`, `header`.
@@ -71,12 +75,15 @@ oauth_flow_bearer_jwt <- function(
     cli::cli_abort("JWT flow requires {.arg client} with a key.")
   }
 
-  if (is_list(claim)) {
-    claim <- exec("jwt_claim", !!!claim)
-  } else if (is.function(claim)) {
-    claim <- claim()
-  } else {
-    cli::cli_abort("{.arg claim} must be a list or function.")
+  claim <- as_jwt_claim(claim)
+
+  # If the client also authenticates itself with a signed JWT (RFC 7523 §2.2),
+  # reuse this claim so it doesn't have to be specified twice (#825).
+  if (
+    identical(client$auth, "oauth_client_req_auth_jwt_sig") &&
+      !has_name(client$auth_params, "claim")
+  ) {
+    client$auth_params$claim <- claim
   }
 
   jwt <- exec(signature, claim = claim, key = client$key, !!!signature_params)

--- a/R/oauth-flow-jwt.R
+++ b/R/oauth-flow-jwt.R
@@ -20,8 +20,9 @@
 #'   callback function which should call `jwt_claim()`.
 #'
 #'   If `client` authenticates itself with `auth = "jwt_sig"`, this `claim` is
-#'   reused for the client assertion unless the client supplies its own `claim`
-#'   in `auth_params`.
+#'   used as the basis for a separate client assertion unless the client
+#'   supplies its own `claim` in `auth_params`. The client assertion claim uses
+#'   `client$id` as its `sub`.
 #' @param signature Function use to sign `claim`, e.g. [jwt_encode_sig()].
 #' @param signature_params Additional arguments passed to `signature`, e.g.
 #'   `size`, `header`.
@@ -75,15 +76,17 @@ oauth_flow_bearer_jwt <- function(
     cli::cli_abort("JWT flow requires {.arg client} with a key.")
   }
 
+  claim_spec <- claim
   claim <- as_jwt_claim(claim)
 
   # If the client also authenticates itself with a signed JWT (RFC 7523 §2.2),
-  # reuse this claim so it doesn't have to be specified twice (#825).
+  # derive a client assertion claim so it doesn't have to be specified twice
+  # (#825).
   if (
     identical(client$auth, "oauth_client_req_auth_jwt_sig") &&
       !has_name(client$auth_params, "claim")
   ) {
-    client$auth_params$claim <- claim
+    client$auth_params$claim <- as_jwt_client_claim(claim_spec, client$id)
   }
 
   jwt <- exec(signature, claim = claim, key = client$key, !!!signature_params)

--- a/man/oauth_client_req_auth.Rd
+++ b/man/oauth_client_req_auth.Rd
@@ -13,7 +13,13 @@ oauth_client_req_auth_header(req, client)
 
 oauth_client_req_auth_body(req, client)
 
-oauth_client_req_auth_jwt_sig(req, client, claim, size = 256, header = list())
+oauth_client_req_auth_jwt_sig(
+  req,
+  client,
+  claim = NULL,
+  size = 256,
+  header = list()
+)
 }
 \arguments{
 \item{req}{A httr2 \link{request} object.}

--- a/man/req_oauth_bearer_jwt.Rd
+++ b/man/req_oauth_bearer_jwt.Rd
@@ -36,8 +36,9 @@ If other components need to vary, you can instead provide a zero-argument
 callback function which should call \code{jwt_claim()}.
 
 If \code{client} authenticates itself with \code{auth = "jwt_sig"}, this \code{claim} is
-reused for the client assertion unless the client supplies its own \code{claim}
-in \code{auth_params}.}
+used as the basis for a separate client assertion unless the client
+supplies its own \code{claim} in \code{auth_params}. The client assertion claim uses
+\code{client$id} as its \code{sub}.}
 
 \item{signature}{Function use to sign \code{claim}, e.g. \code{\link[=jwt_encode_sig]{jwt_encode_sig()}}.}
 

--- a/man/req_oauth_bearer_jwt.Rd
+++ b/man/req_oauth_bearer_jwt.Rd
@@ -33,7 +33,11 @@ oauth_flow_bearer_jwt(
 apart from \code{iat}, \code{nbf}, \code{exp}, or \code{jti}, provide a list and
 \code{\link[=jwt_claim]{jwt_claim()}} will automatically fill in the dynamic components.
 If other components need to vary, you can instead provide a zero-argument
-callback function which should call \code{jwt_claim()}.}
+callback function which should call \code{jwt_claim()}.
+
+If \code{client} authenticates itself with \code{auth = "jwt_sig"}, this \code{claim} is
+reused for the client assertion unless the client supplies its own \code{claim}
+in \code{auth_params}.}
 
 \item{signature}{Function use to sign \code{claim}, e.g. \code{\link[=jwt_encode_sig]{jwt_encode_sig()}}.}
 

--- a/tests/testthat/_snaps/oauth-client.md
+++ b/tests/testthat/_snaps/oauth-client.md
@@ -30,11 +30,6 @@
       Error in `oauth_client()`:
       ! `auth = 'jwt_sig'` requires a `key`.
     Code
-      oauth_client("abc", "http://x.com", key = "abc", auth = "jwt_sig")
-    Condition
-      Error in `oauth_client()`:
-      ! `auth = 'jwt_sig'` requires a claim specification in `auth_params`.
-    Code
       oauth_client("abc", "http://x.com", auth = 123)
     Condition
       Error in `oauth_client()`:
@@ -87,4 +82,12 @@
     Condition
       Error in `oauth_client()`:
       ! `metadata` must be created with `oauth_server_metadata()`.
+
+# jwt_sig auth requires a claim
+
+    Code
+      oauth_client_req_auth(request("http://example.com"), client)
+    Condition
+      Error in `oauth_client_req_auth_jwt_sig()`:
+      ! `auth = 'jwt_sig'` requires a `claim` in `auth_params`.
 

--- a/tests/testthat/test-oauth-client.R
+++ b/tests/testthat/test-oauth-client.R
@@ -11,7 +11,6 @@ test_that("checks auth types have needed args", {
   expect_snapshot(error = TRUE, {
     oauth_client("abc", "http://x.com", auth = "header")
     oauth_client("abc", "http://x.com", auth = "jwt_sig")
-    oauth_client("abc", "http://x.com", key = "abc", auth = "jwt_sig")
     oauth_client("abc", "http://x.com", auth = 123)
   })
 })
@@ -103,5 +102,35 @@ test_that("can authenticate using header or body", {
   expect_equal(
     req_b$body$data,
     list(client_id = I("id"), client_secret = I("secret"))
+  )
+})
+
+test_that("can authenticate using a signed jwt", {
+  skip_if_not_installed("jose")
+  skip_if_not_installed("openssl")
+
+  client <- oauth_client(
+    "id",
+    "http://example.com",
+    key = openssl::rsa_keygen(),
+    auth = "jwt_sig",
+    auth_params = list(claim = jwt_claim())
+  )
+  req <- oauth_client_req_auth(request("http://example.com"), client)
+  expect_named(req$body$data, c("client_assertion", "client_assertion_type"))
+})
+
+test_that("jwt_sig auth requires a claim", {
+  skip_if_not_installed("openssl")
+
+  client <- oauth_client(
+    "id",
+    "http://example.com",
+    key = openssl::rsa_keygen(),
+    auth = "jwt_sig"
+  )
+  expect_snapshot(
+    oauth_client_req_auth(request("http://example.com"), client),
+    error = TRUE
   )
 })

--- a/tests/testthat/test-oauth-flow-jwt.R
+++ b/tests/testthat/test-oauth-flow-jwt.R
@@ -35,6 +35,26 @@ test_that("can generate token and use it automatically", {
   expect_equal(resp$email_verified, TRUE)
 })
 
+test_that("reuses claim for jwt_sig client auth (#825)", {
+  skip_if_not_installed("jose")
+  skip_if_not_installed("openssl")
+
+  client <- oauth_client(
+    "id",
+    "http://example.com",
+    key = openssl::rsa_keygen(),
+    auth = "jwt_sig"
+  )
+
+  captured <- NULL
+  local_mocked_bindings(
+    oauth_client_get_token = function(client, ...) captured <<- client
+  )
+
+  oauth_flow_bearer_jwt(client, claim = jwt_claim())
+  expect_s3_class(captured$auth_params$claim, "jwt_claim")
+})
+
 test_that("validates inputs", {
   client1 <- oauth_client("test", "http://example.com")
   expect_snapshot(oauth_flow_bearer_jwt(client1), error = TRUE)

--- a/tests/testthat/test-oauth-flow-jwt.R
+++ b/tests/testthat/test-oauth-flow-jwt.R
@@ -51,8 +51,14 @@ test_that("reuses claim for jwt_sig client auth (#825)", {
     oauth_client_get_token = function(client, ...) captured <<- client
   )
 
-  oauth_flow_bearer_jwt(client, claim = jwt_claim())
+  claim <- jwt_claim(iss = "issuer", sub = "user", aud = "audience")
+  oauth_flow_bearer_jwt(client, claim = claim)
+
   expect_s3_class(captured$auth_params$claim, "jwt_claim")
+  expect_equal(captured$auth_params$claim$iss, "issuer")
+  expect_equal(captured$auth_params$claim$sub, "id")
+  expect_equal(captured$auth_params$claim$aud, "audience")
+  expect_equal(captured$auth_params$claim$jti == claim$jti, FALSE)
 })
 
 test_that("validates inputs", {


### PR DESCRIPTION
`req_oauth_bearer_jwt()` uses a JWT as an authorization grant (RFC 7523 §2.1), while `oauth_client(auth = "jwt_sig")` uses a JWT to authenticate the client (§2.2). When both were combined, the same `claim` had to be supplied twice.

Now the bearer JWT flow reuses its `claim` for the client assertion when the client doesn't carry its own, so `oauth_client(auth = "jwt_sig")` no longer requires a `claim` in `auth_params` at creation time; the requirement is instead enforced at request time.

Fixes #825