### PR TITLE
Support multiple rate limits in `req_throttle()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 e.g., `application/problem+json` (@cgiachalis, #782).
 * `req_body_form()` now creates a valid empty request body when no parameters
   are provided (@arcresu, #836).
+* `req_throttle()` can now enforce multiple rate limits at once: supply a vector to `capacity` (and `fill_time_s`) to create one token bucket per limit, and each request must satisfy all of them (#555).
 
 # httr2 1.2.2
 

--- a/R/req-throttle.R
+++ b/R/req-throttle.R
@@ -15,9 +15,18 @@
 #' same average throttling rate as the previous approach, but gives you much
 #' better performance if you're only making a small number of requests.
 #'
+#' Some APIs enforce multiple rate limits simultaneously, e.g. no more than
+#' 4 requests per second *and* no more than 200 requests per hour. You can
+#' handle this by supplying a vector to `capacity` and `fill_time_s`: this
+#' creates one token bucket per limit, and each request must satisfy all of
+#' them. This lets you make quick bursts of requests while still respecting
+#' longer term limits.
+#'
 #' @inheritParams req_perform
 #' @param capacity The size of the bucket, i.e. the maximum number of
-#'   tokens that can accumulate.
+#'   tokens that can accumulate. To enforce multiple rate limits at once,
+#'   supply a vector of capacities (one per limit); `capacity` and
+#'   `fill_time_s` are recycled to a common length.
 #' @param rate For backwards compatibility, you can still specify the `rate`,
 #'   which is converted to `capacity` by multiplying by `fill_time_s`.
 #'   However, we recommend using `capacity` and `fill_time_s` as it gives more
@@ -38,50 +47,105 @@
 #' throttle_status()
 #' resp <- req_perform(req)
 #' throttle_status()
+#' \dontshow{httr2:::throttle_reset()}
 #'
+#' # Enforce multiple limits at once: no more than 10 requests every 1s
+#' # and no more than 100 requests every 60s
+#' req <- request(example_url()) |>
+#'   req_throttle(capacity = c(10, 100), fill_time_s = c(1, 60))
+#' resp <- req_perform(req)
+#' throttle_status()
 #' \dontshow{httr2:::throttle_reset()}
 req_throttle <- function(req, rate, capacity, fill_time_s = 60, realm = NULL) {
   check_request(req)
   check_exclusive(rate, capacity)
-  if (missing(capacity)) {
-    check_number_decimal(rate, min = 0)
-    capacity <- rate * fill_time_s
-  } else {
-    check_number_whole(capacity, min = 0)
-    rate <- capacity / fill_time_s
-  }
-  check_number_decimal(fill_time_s, min = 0)
+  check_throttle_number(fill_time_s)
   check_string(realm, allow_null = TRUE)
 
+  if (missing(capacity)) {
+    check_throttle_number(rate)
+    args <- vctrs::vec_recycle_common(rate = rate, fill_time_s = fill_time_s)
+    capacity <- args$rate * args$fill_time_s
+  } else {
+    check_throttle_number(capacity, whole = TRUE)
+    args <- vctrs::vec_recycle_common(
+      capacity = capacity,
+      fill_time_s = fill_time_s
+    )
+    capacity <- args$capacity
+  }
+  fill_rate <- capacity / args$fill_time_s
+
   realm <- realm %||% url_parse(req$url)$hostname
-  if (!throttle_exists(realm, capacity, rate)) {
-    the$throttle[[realm]] <- TokenBucket$new(capacity, rate)
+  if (!throttle_exists(realm, capacity, fill_rate)) {
+    the$throttle[[realm]] <- map2(
+      capacity,
+      fill_rate,
+      function(capacity, fill_rate) TokenBucket$new(capacity, fill_rate)
+    )
   }
   req_policies(req, throttle_realm = realm)
+}
+
+# Validates a non-negative numeric vector of throttle parameters.
+check_throttle_number <- function(
+  x,
+  whole = FALSE,
+  arg = caller_arg(x),
+  call = caller_env()
+) {
+  if (missing(x) || !is.numeric(x) || length(x) == 0 || anyNA(x)) {
+    stop_input_type(x, "a numeric vector", arg = arg, call = call)
+  }
+  if (any(x < 0)) {
+    cli::cli_abort(
+      "Every element of {.arg {arg}} must be 0 or greater.",
+      call = call
+    )
+  }
+  if (whole && any(x != trunc(x))) {
+    cli::cli_abort(
+      "Every element of {.arg {arg}} must be a whole number.",
+      call = call
+    )
+  }
+  invisible()
 }
 
 #' Display internal throttle status
 #'
 #' Sometimes useful for debugging.
 #'
-#' @return A data frame with three columns:
+#' @return A data frame with one row per token bucket and four columns:
 #'   * The `realm`.
+#'   * The `capacity` of the bucket.
 #'   * Number of `tokens` remaining in the bucket.
 #'   * Time `to_wait` in seconds for next token.
 #' @export
 #' @keywords internal
 throttle_status <- function() {
   # Trigger refill before displaying status
-  walk(the$throttle, function(x) x$refill())
+  walk(the$throttle, function(buckets) walk(buckets, function(b) b$refill()))
 
-  df <- data.frame(
-    realm = env_names(the$throttle),
-    tokens = floor(map_dbl(the$throttle, function(x) x$tokens)),
-    to_wait = map_dbl(the$throttle, function(x) x$token_wait_time()),
+  realm <- character()
+  capacity <- tokens <- to_wait <- double()
+  # Just for debugging so focus on simplicity rather than efficiency
+  for (r in sort(env_names(the$throttle))) {
+    buckets <- the$throttle[[r]]
+    realm <- c(realm, rep(r, length(buckets)))
+    capacity <- c(capacity, map_dbl(buckets, function(b) b$capacity))
+    tokens <- c(tokens, floor(map_dbl(buckets, function(b) b$tokens)))
+    to_wait <- c(to_wait, map_dbl(buckets, function(b) b$token_wait_time()))
+  }
+
+  data.frame(
+    realm = realm,
+    capacity = capacity,
+    tokens = tokens,
+    to_wait = to_wait,
     row.names = NULL,
     check.names = FALSE
   )
-  df[order(df$realm), , drop = FALSE]
 }
 
 throttle_reset <- function(realm = NULL) {
@@ -99,22 +163,28 @@ throttle_exists <- function(realm, capacity, fill_rate) {
     return(FALSE)
   }
 
-  cur_throttle <- the$throttle[[realm]]
-  cur_throttle$capacity == capacity && cur_throttle$fill_rate == fill_rate
+  buckets <- the$throttle[[realm]]
+  length(buckets) == length(capacity) &&
+    all(map_dbl(buckets, \(b) b$capacity) == capacity) &&
+    all(map_dbl(buckets, \(b) b$fill_rate) == fill_rate)
 }
 
 throttle_delay <- function(req) {
   if (!req_policy_exists(req, "throttle_realm")) {
     0
   } else {
-    the$throttle[[req$policies$throttle_realm]]$take_token()
+    # Each request takes a token from every bucket, but only needs to wait
+    # for the slowest one to refill.
+    buckets <- the$throttle[[req$policies$throttle_realm]]
+    max(map_dbl(buckets, \(b) b$take_token()))
   }
 }
 throttle_deadline <- function(req) {
   unix_time() + throttle_delay(req)
 }
 throttle_return_token <- function(req) {
-  the$throttle[[req$policies$throttle_realm]]$return_token()
+  buckets <- the$throttle[[req$policies$throttle_realm]]
+  walk(buckets, \(b) b$return_token())
 }
 
 TokenBucket <- R6::R6Class(

--- a/man/req_throttle.Rd
+++ b/man/req_throttle.Rd
@@ -15,7 +15,9 @@ However, we recommend using \code{capacity} and \code{fill_time_s} as it gives m
 control.}
 
 \item{capacity}{The size of the bucket, i.e. the maximum number of
-tokens that can accumulate.}
+tokens that can accumulate. To enforce multiple rate limits at once,
+supply a vector of capacities (one per limit); \code{capacity} and
+\code{fill_time_s} are recycled to a common length.}
 
 \item{fill_time_s}{Time in seconds to fill the capacity. Defaults to 60s.}
 
@@ -40,6 +42,13 @@ requests more quickly if the bucket is full. For example, if you have
 without waiting, but the next request will wait 60 seconds. This gives the
 same average throttling rate as the previous approach, but gives you much
 better performance if you're only making a small number of requests.
+
+Some APIs enforce multiple rate limits simultaneously, e.g. no more than
+4 requests per second \emph{and} no more than 200 requests per hour. You can
+handle this by supplying a vector to \code{capacity} and \code{fill_time_s}: this
+creates one token bucket per limit, and each request must satisfy all of
+them. This lets you make quick bursts of requests while still respecting
+longer term limits.
 }
 \examples{
 # Ensure we never send more than 30 requests a minute
@@ -50,7 +59,12 @@ resp <- req_perform(req)
 throttle_status()
 resp <- req_perform(req)
 throttle_status()
+\dontshow{httr2:::throttle_reset()}
 
+# Enforce multiple limits at once: no more than 10 requests every 10s
+# and no more than 50 requests every 60s
+req <- request(example_url()) |>
+  req_throttle(capacity = c(10, 50), fill_time_s = c(10, 60))
 \dontshow{httr2:::throttle_reset()}
 }
 \seealso{

--- a/man/throttle_status.Rd
+++ b/man/throttle_status.Rd
@@ -7,9 +7,10 @@
 throttle_status()
 }
 \value{
-A data frame with three columns:
+A data frame with one row per token bucket and four columns:
 \itemize{
 \item The \code{realm}.
+\item The \code{capacity} of the bucket.
 \item Number of \code{tokens} remaining in the bucket.
 \item Time \code{to_wait} in seconds for next token.
 }

--- a/tests/testthat/_snaps/req-throttle.md
+++ b/tests/testthat/_snaps/req-throttle.md
@@ -5,3 +5,26 @@
     Message
       > Waiting 0.15s for throttling delay
 
+# req_throttle checks its inputs
+
+    Code
+      req_throttle(request_test(), capacity = "x")
+    Condition
+      Error in `req_throttle()`:
+      ! `capacity` must be a numeric vector, not the string "x".
+    Code
+      req_throttle(request_test(), capacity = -1)
+    Condition
+      Error in `req_throttle()`:
+      ! Every element of `capacity` must be 0 or greater.
+    Code
+      req_throttle(request_test(), capacity = 1.5)
+    Condition
+      Error in `req_throttle()`:
+      ! Every element of `capacity` must be a whole number.
+    Code
+      req_throttle(request_test(), capacity = c(1, 2), fill_time_s = c(1, 2, 3))
+    Condition
+      Error in `req_throttle()`:
+      ! Can't recycle `capacity` (size 2) to match `fill_time_s` (size 3).
+

--- a/tests/testthat/test-req-perform-parallel.R
+++ b/tests/testthat/test-req-perform-parallel.R
@@ -311,12 +311,12 @@ test_that("throttling is limited by deadline", {
   expect_equal(queue$queue_status, "waiting")
   queue$process1(1)
   expect_equal(mock_time, 1)
-  expect_equal(the$throttle[["test"]]$tokens, 1)
+  expect_equal(the$throttle[["test"]][[1]]$tokens, 1)
 
   local_mocked_bindings(throttle_deadline = function(...) mock_time)
   queue$rate_limit_deadline <- mock_time + 2
   expect_equal(mock_time, 1)
-  expect_equal(the$throttle[["test"]]$tokens, 1)
+  expect_equal(the$throttle[["test"]][[1]]$tokens, 1)
 })
 
 

--- a/tests/testthat/test-req-throttle.R
+++ b/tests/testthat/test-req-throttle.R
@@ -66,6 +66,73 @@ test_that("realm defaults to hostname but can be overridden", {
   expect_named(the$throttle, "custom")
 })
 
+test_that("can enforce multiple limits in a single realm", {
+  on.exit(throttle_reset())
+
+  mock_time <- 0
+  local_mocked_bindings(unix_time = function() mock_time)
+
+  # 10 requests/second and 2 requests/minute
+  req <- request_test() |>
+    req_throttle(capacity = c(10, 2), fill_time_s = c(1, 60))
+  expect_length(the$throttle[["127.0.0.1"]], 2)
+
+  # first two are free
+  expect_equal(throttle_delay(req), 0)
+  expect_equal(throttle_delay(req), 0)
+
+  # third must wait for the slow (minute) bucket, even though the fast
+  # (second) bucket still has plenty of tokens
+  expect_equal(throttle_delay(req), 30)
+})
+
+test_that("multiple limits recycle and accept rate", {
+  on.exit(throttle_reset())
+
+  request_test() |> req_throttle(capacity = c(4, 200), fill_time_s = c(1, 3600))
+  buckets <- the$throttle[["127.0.0.1"]]
+  expect_equal(map_dbl(buckets, function(b) b$capacity), c(4, 200))
+  expect_equal(map_dbl(buckets, function(b) b$fill_rate), c(4, 200 / 3600))
+
+  throttle_reset()
+  request_test() |>
+    req_throttle(rate = c(4, 200 / 3600), fill_time_s = c(1, 3600))
+  buckets <- the$throttle[["127.0.0.1"]]
+  expect_equal(map_dbl(buckets, function(b) b$capacity), c(4, 200))
+})
+
+test_that("throttle reset when number of limits changes", {
+  on.exit(throttle_reset())
+
+  mock_time <- 0
+  local_mocked_bindings(unix_time = function() mock_time)
+
+  request_test() |> req_throttle(capacity = 2, fill_time_s = 1)
+  expect_length(the$throttle[["127.0.0.1"]], 1)
+
+  request_test() |> req_throttle(capacity = c(2, 3), fill_time_s = c(1, 60))
+  expect_length(the$throttle[["127.0.0.1"]], 2)
+})
+
+test_that("req_throttle checks its inputs", {
+  expect_snapshot(error = TRUE, {
+    request_test() |> req_throttle(capacity = "x")
+    request_test() |> req_throttle(capacity = -1)
+    request_test() |> req_throttle(capacity = 1.5)
+    request_test() |> req_throttle(capacity = c(1, 2), fill_time_s = c(1, 2, 3))
+  })
+})
+
+test_that("throttle_status reports each bucket", {
+  on.exit(throttle_reset())
+  local_mocked_bindings(unix_time = function() 0)
+
+  request_test() |> req_throttle(capacity = c(2, 3), fill_time_s = c(1, 60))
+  status <- throttle_status()
+  expect_equal(status$realm, c("127.0.0.1", "127.0.0.1"))
+  expect_equal(status$capacity, c(2, 3))
+})
+
 # token bucket ----------------------------------------------------------------
 
 test_that("token bucket respects capacity limits", {


### PR DESCRIPTION
`req_throttle()` now accepts vectors for `capacity`, `rate`, and `fill_time_s`, creating one token bucket per limit within a realm. Each request takes a token from every bucket and waits for the slowest to refill, so quick bursts are allowed while longer-term limits are still respected.

Fixes #555