### PR TITLE
Ignore `NA`s when pruning cache files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_cache()` pruning no longer errors if a cache file is deleted while the cache is being pruned.
+
 # httr2 1.2.3
 
 * Mocked and cached responses now include the originating request in `resp$request`, just like real responses (#841).

--- a/R/req-cache.R
+++ b/R/req-cache.R
@@ -191,6 +191,8 @@ cache_info <- function(path, pattern = "\\.rds$") {
 }
 
 cache_prune_files <- function(info, to_remove, why, debug = TRUE) {
+  to_remove[is.na(to_remove)] <- FALSE
+
   if (any(to_remove)) {
     if (debug) {
       cli::cli_text("Deleted {sum(to_remove)} file{?s} that {?is/are} {why}")

--- a/tests/testthat/test-req-cache.R
+++ b/tests/testthat/test-req-cache.R
@@ -286,6 +286,11 @@ test_that("can prune by size", {
   expect_equal(dir(path), "c.rds")
 })
 
+test_that("cache_prune_files ignores NAs in to_remove", {
+  info <- data.frame(name = c("a", "b"), size = 1, mtime = Sys.time())
+  expect_equal(cache_prune_files(info, c(NA, FALSE), "x", debug = FALSE), info)
+})
+
 # headers -----------------------------------------------------------------
 
 test_that("correctly determines if response is cacheable", {


### PR DESCRIPTION
`file.info()` returns `NA` for files it can't stat, which happens when a cache file is deleted (e.g. by another process, or an OS temp cleaner) between when `cache_info()` lists it with `dir()` and when it stats it. These `NA`s propagated into `to_remove`:

- `if (any(to_remove))` errors with "missing value where TRUE/FALSE needed" when there's an `NA` but no `TRUE`.
- Where there is a `TRUE`, `info[!to_remove, ]` turns `NA`-indexed rows into all-`NA` rows, corrupting later pruning passes.

`cache_prune_files()` now coerces `NA` entries in `to_remove` to `FALSE`, leaving such files in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)