### PR TITLE
Token cache fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .Rproj.user
 docs
 inst/doc
+.posit/assistant/settings.json

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     openssl,
     R6,
     rappdirs,
-    rlang (>= 1.1.0),
+    rlang (>= 1.3.0),
     vctrs (>= 0.6.3),
     withr
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr2 (development version)
 
+* Fixed OAuth token cache pruning so that it actually matches the encrypted `.rds.enc` files written to disk; previously the pruning pattern only matched an unencrypted `.rds` file that was never created, so cached tokens were never automatically deleted regardless of age.
+* httr2 now requires rlang >= 1.3.0, which changes the hash used to name files cached by `req_cache()` and on-disk OAuth token caches (e.g. from `req_oauth_auth_code(cache_disk = TRUE)`). Existing cached files won't match the new hash, so they'll be silently ignored (triggering a normal cache miss/re-authentication) and cleaned up over time by the usual pruning rules; you can also delete them manually.
+
 # httr2 1.2.3
 
 * Mocked and cached responses now include the originating request in `resp$request`, just like real responses (#841).

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -194,7 +194,7 @@ cache_disk_prune <- function(days = 30, path = oauth_cache_path()) {
     path,
     recursive = TRUE,
     full.names = TRUE,
-    pattern = "-token\\.rds$"
+    pattern = "-token\\.rds\\.enc$"
   )
   mtime <- file.mtime(files)
 

--- a/tests/testthat/_snaps/oauth-client.md
+++ b/tests/testthat/_snaps/oauth-client.md
@@ -41,7 +41,7 @@
       oauth_client("x", url)
     Output
       <httr2_oauth_client>
-      * name     : "bf27508f7925b06bf28a10f3805351ab"
+      * name     : "9758a2659d8a24b1be8a873ab9e4da84"
       * id       : "x"
       * token_url: "http://example.com"
       * auth     : "oauth_client_req_auth_body"
@@ -49,7 +49,7 @@
       oauth_client("x", url, secret = "SECRET")
     Output
       <httr2_oauth_client>
-      * name     : "bf27508f7925b06bf28a10f3805351ab"
+      * name     : "9758a2659d8a24b1be8a873ab9e4da84"
       * id       : "x"
       * secret   : <REDACTED>
       * token_url: "http://example.com"
@@ -60,7 +60,7 @@
       })
     Output
       <httr2_oauth_client>
-      * name     : "bf27508f7925b06bf28a10f3805351ab"
+      * name     : "9758a2659d8a24b1be8a873ab9e4da84"
       * id       : "x"
       * token_url: "http://example.com"
       * auth     : <function>

--- a/tests/testthat/_snaps/oauth.md
+++ b/tests/testthat/_snaps/oauth.md
@@ -3,5 +3,5 @@
     Code
       cache$set(1)
     Message
-      Caching httr2 token in '<oauth-cache-path>/httr2-test/ae743e0fbd718c21f2cca632e77bd180-token.rds.enc'.
+      Caching httr2 token in '<oauth-cache-path>/httr2-test/2c0a8a99dc147d5445c3b49d035665b2-token.rds.enc'.
 

--- a/tests/testthat/_snaps/req-cache.md
+++ b/tests/testthat/_snaps/req-cache.md
@@ -8,11 +8,11 @@
     Code
       invisible(cache_post_fetch(req, resp))
     Message
-      Saving response to cache "f3805db63ff822b4743f247cfdde10a3"
+      Saving response to cache "076ab9e79f298c15d4444b2eb6fffa84"
     Code
       invisible(cache_pre_fetch(req))
     Message
-      Found url in cache "f3805db63ff822b4743f247cfdde10a3"
+      Found url in cache "076ab9e79f298c15d4444b2eb6fffa84"
       Cached value is fresh; using response from cache
 
 ---
@@ -22,7 +22,7 @@
       invisible(cache_pre_fetch(req))
     Message
       Pruning cache
-      Found url in cache "f3805db63ff822b4743f247cfdde10a3"
+      Found url in cache "076ab9e79f298c15d4444b2eb6fffa84"
       Cached value is stale; checking for updates
     Code
       invisible(cache_post_fetch(req, response(304)))

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -158,10 +158,10 @@ test_that("can explicitly clear cached value", {
 
 test_that("can prune old files", {
   path <- withr::local_tempdir()
-  touch(file.path(path, "a-token.rds"), Sys.time() - 86400 * 1)
-  touch(file.path(path, "b-token.rds"), Sys.time() - 86400 * 2)
+  touch(file.path(path, "a-token.rds.enc"), Sys.time() - 86400 * 1)
+  touch(file.path(path, "b-token.rds.enc"), Sys.time() - 86400 * 2)
   cache_disk_prune(2, path)
-  expect_equal(dir(path), "a-token.rds")
+  expect_equal(dir(path), "a-token.rds.enc")
 })
 
 # cache_path --------------------------------------------------------------


### PR DESCRIPTION
* Update hashes for rlang 1.3
* Fix bug found by claude; cached tokens were never actually removed