### PR TITLE
Address mocking leakage

### DIFF
--- a/R/pooled-request.R
+++ b/R/pooled-request.R
@@ -78,7 +78,7 @@ PooledRequest <- R6Class(
       )
       handle_preflight(private$req_prep, private$handle)
 
-      curl::multi_add(
+      multi_add(
         handle = private$handle,
         pool = pool,
         data = private$path,
@@ -155,3 +155,15 @@ PooledRequest <- R6Class(
     }
   )
 )
+
+# Wrapper around curl::multi_add() so that the pooled (async) request pathway
+# has a mockable seam, mirroring curl_fetch() for the synchronous pathway.
+multi_add <- function(handle, pool, data, done, fail) {
+  curl::multi_add(
+    handle = handle,
+    pool = pool,
+    data = data,
+    done = done,
+    fail = fail
+  )
+}

--- a/tests/testthat/test-req-perform-connection.R
+++ b/tests/testthat/test-req-perform-connection.R
@@ -162,10 +162,10 @@ test_that("tracing works as expected", {
     resp <- req_perform_connection(request(url_build(parsed)))
     close(resp)
 
-    # A request with a curl error.
+    # A request with a curl error
     with_mocked_bindings(
       try(req_perform_connection(request("http://127.0.0.1")), silent = TRUE),
-      curl_fetch = function(...) abort("Failed to connect")
+      open = function(...) stop("Failed to connect")
     )
 
     # A request that triggers retries, generating three individual spans.

--- a/tests/testthat/test-req-promise.R
+++ b/tests/testthat/test-req-promise.R
@@ -191,7 +191,12 @@ test_that("tracing works as expected", {
         p <- req_perform_promise(request("http://127.0.0.1"))
         try(extract_promise(p), silent = TRUE)
       },
-      curl_fetch = function(...) abort("Failed to connect")
+      multi_add = function(handle, pool, data, done, fail) {
+        fail(structure(
+          "Failed to connect",
+          class = c("curl_error_couldnt_connect", "curl_error", "character")
+        ))
+      }
     )
 
     # A request with no parent context.


### PR DESCRIPTION
# Summary

* Add wrapper function on `curl::multi_add` to allow mock bindings in tests

# Motivation
I am working on running package checks for enterprise group compliance and ran into the following error:
```
── Failure ('test-req-promise.R:227:3'): tracing works as expected ─────────────
Expected `spans[[2]]$attributes$error.type` to equal "curl_error_couldnt_connect".
Differences:
`actual`:   "curl_error_ssl_connect_error"
`expected`: "curl_error_couldnt_connect"  
```

Long story short, I found the `req_perform_promise` does not use `curl_fetch` in the back-end, so the promise misses the mock and interacts with my environment. 

Additionally audited for other situations where `curl_fetch` was used incorrectly and found one for `req_perform_connection`.

# Validation
Before:
```
✓ checking for file ‘httr2/DESCRIPTION’
✓ checking package namespace information
✓ checking package dependencies
✓ checking if this is a source package
✓ checking if there is a namespace
✓ checking for executable files
✓ checking for hidden files and directories
✓ checking for portable file names
✓ checking for sufficient/correct file permissions
✓ checking whether package ‘httr2’ can be installed
✓ checking installed package size
✓ checking package directory
✓ checking ‘build’ directory
✓ checking DESCRIPTION meta-information
✓ checking top-level files
✓ checking for left-over files
✓ checking index information
✓ checking package subdirectories
✓ checking code files for non-ASCII characters
✓ checking R files for syntax errors
✓ checking whether the package can be loaded
✓ checking whether the package can be loaded with stated dependencies
✓ checking whether the package can be unloaded cleanly
✓ checking whether the namespace can be loaded with stated dependencies
✓ checking whether the namespace can be unloaded cleanly
✓ checking loading without being on the library search path
✓ checking whether startup messages can be suppressed
✓ checking dependencies in R code
✓ checking S3 generic/method consistency
✓ checking replacement functions
✓ checking foreign function calls
✓ checking R code for possible problems
✓ checking Rd files
✓ checking Rd metadata
✓ checking Rd cross-references
✓ checking for missing documentation entries
✓ checking for code/documentation mismatches
✓ checking Rd \usage sections
✓ checking Rd contents
✓ checking for unstated dependencies in examples
✓ checking R/sysdata.rda
✓ checking installed files from ‘inst/doc’
✓ checking files in ‘vignettes’
✓ checking examples
✓ checking for unstated dependencies in ‘tests’
✗ checking tests
	  Running ‘testthat.R’
	Running the tests in ‘tests/testthat.R’ failed.
	Last 13 lines of output:
	  • clipr::clipr_available() is not TRUE (1): 'test-curl.R:218:3'
	  • has_paws_credentials() is not TRUE (1): 'test-req-auth-aws.R:31:3'
	  
	  ══ Failed tests ════════════════════════════════════════════════════════════════
	  ── Failure ('test-req-promise.R:227:3'): tracing works as expected ─────────────
	  Expected `spans[[2]]$attributes$error.type` to equal "curl_error_couldnt_connect".
	  Differences:
	  `actual`:   "curl_error_ssl_connect_error"
	  `expected`: "curl_error_couldnt_connect"  
	  
	  
	  [ FAIL 1 | WARN 0 | SKIP 3 | PASS 1304 ]
	  Error:
	  ! Test failures.
	  Execution halted
✓ checking for unstated dependencies in vignettes
✓ checking package vignettes
✓ checking re-building of vignette outputs
✓ checking PDF version of manual
1 error(s), 0 warning(s), 0 note(s)
```

After:
```
✓ checking for file ‘httr2/DESCRIPTION’
✓ checking package namespace information
✓ checking package dependencies
✓ checking if this is a source package
✓ checking if there is a namespace
✓ checking for executable files
✓ checking for hidden files and directories
✓ checking for portable file names
✓ checking for sufficient/correct file permissions
✓ checking whether package ‘httr2’ can be installed
✓ checking installed package size
✓ checking package directory
✓ checking ‘build’ directory
✓ checking DESCRIPTION meta-information
✓ checking top-level files
✓ checking for left-over files
✓ checking index information
✓ checking package subdirectories
✓ checking code files for non-ASCII characters
✓ checking R files for syntax errors
✓ checking whether the package can be loaded
✓ checking whether the package can be loaded with stated dependencies
✓ checking whether the package can be unloaded cleanly
✓ checking whether the namespace can be loaded with stated dependencies
✓ checking whether the namespace can be unloaded cleanly
✓ checking loading without being on the library search path
✓ checking whether startup messages can be suppressed
✓ checking dependencies in R code
✓ checking S3 generic/method consistency
✓ checking replacement functions
✓ checking foreign function calls
✓ checking R code for possible problems
✓ checking Rd files
✓ checking Rd metadata
✓ checking Rd cross-references
✓ checking for missing documentation entries
✓ checking for code/documentation mismatches
✓ checking Rd \usage sections
✓ checking Rd contents
✓ checking for unstated dependencies in examples
✓ checking R/sysdata.rda
✓ checking installed files from ‘inst/doc’
✓ checking files in ‘vignettes’
✓ checking examples
✓ checking for unstated dependencies in ‘tests’
✓ checking tests
	  Running ‘testthat.R’
✓ checking for unstated dependencies in vignettes
✓ checking package vignettes
✓ checking re-building of vignette outputs
✓ checking PDF version of manual
All good!
```