### PR TITLE
Restrict permissions on disk token cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* The on-disk OAuth token cache (used by `req_oauth_*(cache_disk = TRUE)`) now creates its directories with mode `700` and token files with mode `600` so that cached tokens are not readable by other users on the same machine.
+
 # httr2 1.3.0
 
 * Fixed OAuth token cache pruning so that it actually matches the encrypted `.rds.enc` files written to disk; previously the pruning pattern only matched an unencrypted `.rds` file that was never created, so cached tokens were never automatically deleted regardless of age.

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -194,7 +194,9 @@ cache_mem <- function(client, key = NULL) {
 }
 cache_disk <- function(client, key = NULL) {
   app_path <- file.path(oauth_cache_path(), client$name)
-  dir.create(app_path, showWarnings = FALSE, recursive = TRUE)
+  dir.create(app_path, showWarnings = FALSE, recursive = TRUE, mode = "0700")
+  # Fix up directories created by previous versions of httr2
+  Sys.chmod(app_path, "0700")
 
   path <- file.path(app_path, paste0(hash(key), "-token.rds.enc"))
   list(
@@ -204,6 +206,7 @@ cache_disk <- function(client, key = NULL) {
     set = function(token) {
       cli::cli_inform("Caching httr2 token in {.path {path}}.")
       secret_write_rds(token, path, obfuscate_key())
+      Sys.chmod(path, "0600")
     },
     clear = function() if (file.exists(path)) file.remove(path)
   )

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -195,6 +195,28 @@ test_that("can store on disk", {
   expect_equal(cache$get(), NULL)
 })
 
+test_that("disk cache is only accessible to current user", {
+  skip_on_os("windows")
+
+  client <- oauth_client(
+    id = "x",
+    token_url = "http://example.com",
+    name = "httr2-test"
+  )
+  cache <- cache_disk(client, NULL)
+  withr::defer(cache$clear())
+  suppressMessages(cache$set(1))
+
+  app_path <- file.path(oauth_cache_path(), client$name)
+  token_path <- dir(
+    app_path,
+    pattern = "-token\\.rds\\.enc$",
+    full.names = TRUE
+  )
+  expect_equal(file.mode(app_path), as.octmode("700"))
+  expect_equal(file.mode(token_path), as.octmode("600"))
+})
+
 test_that("can explicitly clear cached value", {
   client <- oauth_client(
     id = "x",

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -196,8 +196,6 @@ test_that("can store on disk", {
 })
 
 test_that("disk cache is only accessible to current user", {
-  skip_on_os("windows")
-
   client <- oauth_client(
     id = "x",
     token_url = "http://example.com",
@@ -206,7 +204,10 @@ test_that("disk cache is only accessible to current user", {
   cache <- cache_disk(client, NULL)
   withr::defer(cache$clear())
   suppressMessages(cache$set(1))
+  expect_equal(cache$get(), 1)
 
+  # On Windows Sys.chmod() only affects the read-only attribute
+  skip_on_os("windows")
   app_path <- file.path(oauth_cache_path(), client$name)
   token_path <- dir(
     app_path,


### PR DESCRIPTION
The on-disk OAuth token cache was created with default permissions: directories at 755 and token files at 644 (subject to umask), so cached tokens were readable by other local users. Since the "encryption" of these files uses a key shipped inside the package, file permissions are the real line of defense on multi-user machines.

This PR:

* Creates the cache directory with mode `0700`, and re-applies that mode on each use so directories created by earlier versions of httr2 are also fixed up.
* Chmods each token file to `0600` after writing, matching the hardening `secret_decrypt_file()` already applies.

Both changes are no-ops on Windows, where these modes don't apply; the new test is skipped there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)