### PR TITLE
Include query string in `req_dry_run()` output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr2 (development version)
 
+* `req_dry_run()` now shows the URL's query string in the printed request line and returns it in the `query` element of its result; previously both omitted it (@wikisqueaks, #868).
+
 # httr2 1.3.0
 
 * Fixed OAuth token cache pruning so that it actually matches the encrypted `.rds.enc` files written to disk; previously the pruning pattern only matched an unencrypted `.rds` file that was never created, so cached tokens were never automatically deleted regardless of age.

--- a/R/req-dry-run.R
+++ b/R/req-dry-run.R
@@ -26,7 +26,7 @@
 #'     built.
 #' @param pretty_json If `TRUE`, automatically prettify JSON bodies.
 #' @returns Invisibly, a list containing information about the request,
-#'   including `method`, `path`, and `headers`.
+#'   including `method`, `path`, `query`, and `headers`.
 #' @export
 #' @examples
 #' # httr2 adds default User-Agent, Accept, and Accept-Encoding headers
@@ -70,7 +70,7 @@ req_dry_run <- function(
   )
 
   if (!quiet) {
-    cli::cat_line(resp$method, " ", resp$path, " HTTP/1.1")
+    cli::cat_line(resp$method, " ", resp$path, resp$query, " HTTP/1.1")
 
     if (testing_headers) {
       # curl::curl_echo() overrides
@@ -85,6 +85,7 @@ req_dry_run <- function(
   invisible(list(
     method = resp$method,
     path = resp$path,
+    query = resp$query,
     body = resp$body,
     headers = headers_flatten(headers, redact = redact_headers)
   ))

--- a/man/req_dry_run.Rd
+++ b/man/req_dry_run.Rd
@@ -39,7 +39,7 @@ built.
 }
 \value{
 Invisibly, a list containing information about the request,
-including \code{method}, \code{path}, and \code{headers}.
+including \code{method}, \code{path}, \code{query}, and \code{headers}.
 }
 \description{
 This shows you exactly what httr2 will send to the server, without

--- a/tests/testthat/_snaps/req-dry-run.md
+++ b/tests/testthat/_snaps/req-dry-run.md
@@ -64,3 +64,12 @@
       authorization: Basic dXNlcjpwYXNzd29yZA==
       
 
+# query strings are shown (#868)
+
+    Code
+      out <- req_dry_run(req)
+    Output
+      GET /example-path?a=1&b=2&c=3 HTTP/1.1
+      accept: */*
+      
+

--- a/tests/testthat/test-req-dry-run.R
+++ b/tests/testthat/test-req-dry-run.R
@@ -38,3 +38,15 @@ test_that("doen't add space to urls (#567)", {
   req <- request("https://example.com/test:1:2")
   expect_output(req_dry_run(req), "test:1:2")
 })
+
+test_that("query strings are shown (#868)", {
+  req <- request("http://example.com") |>
+    req_url_path_append("example-path") |>
+    req_url_query(a = "1", b = "2", c = "3")
+  expect_snapshot(out <- req_dry_run(req))
+  expect_equal(out$path, "/example-path")
+  expect_equal(out$query, "?a=1&b=2&c=3")
+
+  out <- req_dry_run(request("http://example.com"), quiet = TRUE)
+  expect_equal(out$query, "")
+})


### PR DESCRIPTION
`curl::curl_echo()` splits the request into separate `path` and `query`
fields, but only `path` was used, so the printed request line and the
returned list both omitted the query. The httr2 1.0.0 blog post shows
`HEAD /?param=value HTTP/1.1`, so this appears to be a regression.

`query` is returned verbatim, including the leading `?` that httpuv puts
in `QUERY_STRING` — happy to strip it if you'd rather it matched `path`.

Existing snapshots are unchanged, since they all use query-less URLs.

Fixes #868.